### PR TITLE
Add: カテゴリ別のindex

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  skip_before_action :require_login, only: %i[show]
 
   def show
     @posts = Category.find(params[:id]).post_categories.includes(:post).order(created_at: :desc)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,9 @@
 class CategoriesController < ApplicationController
-  skip_before_action :require_login, only: %i[show]
+  skip_before_action :require_login, only: %i[index show]
+
+  def index 
+    @posts = Post.all.includes(:user).order(created_at: :desc)
+  end
 
   def show
     @posts = Category.find(params[:id]).post_categories.includes(:post).order(created_at: :desc)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,11 +1,18 @@
 class CategoriesController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
+  before_action :set_category, only: %i[show]
 
   def index 
     @posts = Post.all.includes(:user).order(created_at: :desc)
   end
 
   def show
-    @posts = Category.find(params[:id]).post_categories.includes(:post).order(created_at: :desc)
+    @posts = @category.post_categories.includes(:post).order(created_at: :desc)
+  end
+
+  private
+
+  def set_category
+    @category = Category.find(params[:id])
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -12,7 +12,11 @@ class CategoriesController < ApplicationController
 
   private
 
+  def to_params
+    name
+  end
+
   def set_category
-    @category = Category.find(params[:id])
+    @category = Category.find_by(name: params[:name])
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,6 @@
+class CategoriesController < ApplicationController
+
+  def show
+    @posts = Category.find(params[:id]).post_categories.includes(:post).order(created_at: :desc)
+  end
+end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,5 @@
 class CategoriesController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
-  #before_action :set_category, only: %i[show]
 
   def index 
     @posts = Post.all.includes(:user).order(created_at: :desc)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,12 +1,13 @@
 class CategoriesController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
-  before_action :set_category, only: %i[show]
+  #before_action :set_category, only: %i[show]
 
   def index 
     @posts = Post.all.includes(:user).order(created_at: :desc)
   end
 
   def show
+    @category = Category.find_by(name: params[:name])
     @posts = @category.post_categories.includes(:post).order(created_at: :desc)
   end
 
@@ -14,9 +15,5 @@ class CategoriesController < ApplicationController
 
   def to_params
     name
-  end
-
-  def set_category
-    @category = Category.find_by(name: params[:name])
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,9 +2,9 @@ class TopController < ApplicationController
   skip_before_action :require_login, only: %i[index]
   
   def index
-    @posts = Post.all.includes(:user).order(created_at: :desc).limit(3)
-    @engineer_posts = Category.find_by(name: 'Engineer').post_categories.includes(:post).limit(3)
-    @writer_posts = Category.find_by(name: 'Writer').post_categories.includes(:post).limit(3)
-    @vc_posts = Category.find_by(name: 'Video creator').post_categories.includes(:post).limit(3)
+    @posts = Post.includes(:user, :categories).order(created_at: :desc).limit(3)
+    @engineer_posts = PostCategory.where(category_id: 1).includes(:post, :category).order(created_at: :desc).limit(3)
+    @writer_posts = PostCategory.where(category_id: 2).includes(:post, :category).order(created_at: :desc).limit(3)
+    @vc_posts = PostCategory.where(category_id: 3).includes(:post, :category).order(created_at: :desc).limit(3)
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -4,7 +4,7 @@ class TopController < ApplicationController
   def index
     @posts = Post.all.includes(:user).order(created_at: :desc).limit(3)
     @engineer_posts = Category.find_by(name: 'Engineer').post_categories.includes(:post).limit(3)
-    @gamer_posts = Category.find_by(name: 'Video creator').post_categories.includes(:post).limit(3)
-    @vc_posts = Category.find_by(name: 'Writer').post_categories.includes(:post).limit(3)
+    @writer_posts = Category.find_by(name: 'Writer').post_categories.includes(:post).limit(3)
+    @vc_posts = Category.find_by(name: 'Video creator').post_categories.includes(:post).limit(3)
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,9 +2,9 @@ class TopController < ApplicationController
   skip_before_action :require_login, only: %i[index]
   
   def index
-    @posts = Post.includes(:user, :categories).order(created_at: :desc).limit(3)
-    @engineer_posts = PostCategory.where(category_id: 1).includes(:post, :category).order(created_at: :desc).limit(3)
-    @writer_posts = PostCategory.where(category_id: 2).includes(:post, :category).order(created_at: :desc).limit(3)
-    @creator_posts = PostCategory.where(category_id: 3).includes(:post, :category).order(created_at: :desc).limit(3)
+    @posts = Post.order(created_at: :desc).limit(3)
+    @engineer_posts = Category.find_by(name: 'Engineer').post_categories.includes(:post).order(created_at: :desc).limit(3)
+    @writer_posts = Category.find_by(name: 'Writer').post_categories.includes(:post).order(created_at: :desc).limit(3)
+    @creator_posts = Category.find_by(name: 'MediaCreator').post_categories.includes(:post).order(created_at: :desc).limit(3)
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -5,6 +5,6 @@ class TopController < ApplicationController
     @posts = Post.includes(:user, :categories).order(created_at: :desc).limit(3)
     @engineer_posts = PostCategory.where(category_id: 1).includes(:post, :category).order(created_at: :desc).limit(3)
     @writer_posts = PostCategory.where(category_id: 2).includes(:post, :category).order(created_at: :desc).limit(3)
-    @vc_posts = PostCategory.where(category_id: 3).includes(:post, :category).order(created_at: :desc).limit(3)
+    @creator_posts = PostCategory.where(category_id: 3).includes(:post, :category).order(created_at: :desc).limit(3)
   end
 end

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -1,0 +1,5 @@
+h1 Categories#index
+.row
+  .col-12
+    .row
+      = render @posts

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,4 +1,5 @@
 h1 Categories#show
+h2 #{@category.name}のデスク
 .row
   .col-12
     .row

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,0 +1,5 @@
+h1 Categories#show
+.row
+  .col-12
+    .row
+      = render @posts

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,5 +1,7 @@
 h1 Categories#show
-h2 #{@category.name}のデスク
+p
+h2 
+  = t("category.#{@category.name}")+'のデスク'
 .row
   .col-12
     .row

--- a/app/views/post_categories/_post_category.html.slim
+++ b/app/views/post_categories/_post_category.html.slim
@@ -2,9 +2,3 @@
   div id="post-id-#{post_category.post.id}"
   .card
     = image_tag '20210209_020213.jpg', class: 'card-img-top', size: '300x200'
-    .card-body
-    .ul.list-inline
-      .li.list-inline-item
-        = post_category.post.user.name
-      .li.list-inline-item
-        = l post_category.post.created_at, format: :short

--- a/app/views/post_categories/_post_category.html.slim
+++ b/app/views/post_categories/_post_category.html.slim
@@ -1,4 +1,4 @@
 .col-sm-12.col-lg-4.mb-3
   div id="post-id-#{post_category.post.id}"
-  .card
-    = image_tag '20210209_020213.jpg', class: 'card-img-top', size: '300x200'
+    .card
+      = image_tag '20210209_020213.jpg', class: 'card-img-top', size: '300x200'

--- a/app/views/post_categories/index.html.slim
+++ b/app/views/post_categories/index.html.slim
@@ -1,2 +1,0 @@
-h1 PostCategories#index
-p Find me in app/views/post_categories/index.html.slim

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -2,9 +2,3 @@
   div id="post-id-#{post.id}"
     .card
       = image_tag '20210209_020213.jpg', class: 'card-img-top', size: '300x200'
-      .card-body
-      .ul.list-inline
-        .li.list-inline-item
-          = post.user.name
-        .li.list-inline-item
-          = l post.created_at, format: :short

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -1,7 +1,12 @@
-= link_to t('defaults.login'), login_path
+= link_to t('DeskTour'), root_path
 p
-= link_to 'Login with Twitter', auth_at_provider_path(:provider => :twitter)
-p
-= link_to 'Login with Google', auth_at_provider_path(:provider => :google)
-p
-= link_to t('defaults.register'), new_user_path
+.container
+  .row
+    .col-md-2
+      = link_to t('defaults.login'), login_path
+    .col-md-2
+      = link_to 'Login with Twitter', auth_at_provider_path(:provider => :twitter)
+    .col-md-2
+      = link_to 'Login with Google', auth_at_provider_path(:provider => :google)
+    .col-md-2
+      = link_to t('defaults.register'), new_user_path

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -17,7 +17,7 @@ h3
     .col-12
       .row
         = render @engineer_posts
-= link_to t('.show more'), category_path('engineer')
+= link_to t('.show more'), category_path('Engineer')
 p
 h3
   = t('category.Writer')
@@ -26,7 +26,7 @@ h3
     .col-12
       .row
         = render @writer_posts
-= link_to t('.show more'), category_path('writer')
+= link_to t('.show more'), category_path('Writer')
 p
 h3
   = t('category.Media Creator')
@@ -35,4 +35,4 @@ h3
     .col-12
       .row
         = render @creator_posts
-= link_to t('.show more'), category_path('media creator')
+= link_to t('.show more'), category_path('MediaCreator')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -16,6 +16,7 @@ h3
     .col-12
       .row
         = render @engineer_posts
+  /= link_to t('.engineers desk'), category_path()
 p
 h3
   = t('defaults.Writer')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -23,7 +23,7 @@ h3
   .row
     .col-12
       .row
-        = render @gamer_posts
+        = render @writer_posts
 p
 h3
   = t('defaults.Video Creator')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -29,7 +29,7 @@ h3
 = link_to t('.show more'), category_path('Writer')
 p
 h3
-  = t('category.Media Creator')
+  = t('category.MediaCreator')
 .post_mediacreator
   .row
     .col-12

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -17,7 +17,7 @@ h3
     .col-12
       .row
         = render @engineer_posts
-  = link_to t('.show more'), category_path(id: 1)
+  = link_to t('.show more'), category_path('engineer')
 p
 h3
   = t('defaults.Writer')
@@ -26,7 +26,7 @@ h3
     .col-12
       .row
         = render @writer_posts
-  = link_to t('.show more'), category_path(id: 2)
+  = link_to t('.show more'), category_path('writer')
 p
 h3
   = t('defaults.Video Creator')
@@ -35,4 +35,4 @@ h3
     .col-12
       .row
         = render @vc_posts
-  = link_to t('.show more'), category_path(id: 3)
+  = link_to t('.show more'), category_path('Video creator')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -11,7 +11,7 @@ h3
   = link_to t('.show more'), categories_path
 p
 h3
-  = t('defaults.Engineer')
+  = t('category.Engineer')
 .post_engineer
   .row
     .col-12
@@ -20,7 +20,7 @@ h3
   = link_to t('.show more'), category_path('engineer')
 p
 h3
-  = t('defaults.Writer')
+  = t('category.Writer')
 .post_writer
   .row
     .col-12
@@ -29,10 +29,10 @@ h3
   = link_to t('.show more'), category_path('writer')
 p
 h3
-  = t('defaults.Video Creator')
-.post_videocreator
+  = t('category.Media Creator')
+.post_mediacreator
   .row
     .col-12
       .row
-        = render @vc_posts
-  = link_to t('.show more'), category_path('Video creator')
+        = render @creator_posts
+  = link_to t('.show more'), category_path('media creator')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -8,7 +8,7 @@ h3
     .col-12
       .row
         = render @posts
-  = link_to t('.show more'), categories_path
+= link_to t('.show more'), categories_path
 p
 h3
   = t('category.Engineer')
@@ -17,7 +17,7 @@ h3
     .col-12
       .row
         = render @engineer_posts
-  = link_to t('.show more'), category_path('engineer')
+= link_to t('.show more'), category_path('engineer')
 p
 h3
   = t('category.Writer')
@@ -26,7 +26,7 @@ h3
     .col-12
       .row
         = render @writer_posts
-  = link_to t('.show more'), category_path('writer')
+= link_to t('.show more'), category_path('writer')
 p
 h3
   = t('category.Media Creator')
@@ -35,4 +35,4 @@ h3
     .col-12
       .row
         = render @creator_posts
-  = link_to t('.show more'), category_path('media creator')
+= link_to t('.show more'), category_path('media creator')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -8,6 +8,7 @@ h3
     .col-12
       .row
         = render @posts
+  = link_to t('.show more'), categories_path
 p
 h3
   = t('defaults.Engineer')
@@ -16,7 +17,7 @@ h3
     .col-12
       .row
         = render @engineer_posts
-  /= link_to t('.engineers desk'), category_path()
+  = link_to t('.show more'), category_path(id: 1)
 p
 h3
   = t('defaults.Writer')
@@ -25,6 +26,7 @@ h3
     .col-12
       .row
         = render @writer_posts
+  = link_to t('.show more'), category_path(id: 2)
 p
 h3
   = t('defaults.Video Creator')
@@ -33,3 +35,4 @@ h3
     .col-12
       .row
         = render @vc_posts
+  = link_to t('.show more'), category_path(id: 3)

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,7 +5,7 @@ ja:
     logout: 'ログアウト'
   category:
     Engineer: 'エンジニア'
-    Media Creator: 'メディアクリエイター'
+    MediaCreator: 'メディアクリエイター'
     Writer: 'ライター / エディター'
     Designer: 'デザイナー / イラストレーター'
     Director: 'ディレクター / マーケター'
@@ -19,6 +19,8 @@ ja:
   user_sessions:
     new:
       title: 'ログイン'
+  categories:
+    show:
   time:
     formats:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,10 +3,13 @@ ja:
     login: 'ログイン'
     register: 'ユーザー登録'
     logout: 'ログアウト'
+  category:
     Engineer: 'エンジニア'
-    Gamer: 'ゲーマー'
-    Video Creator: '動画系クリエイター'
-    Writer: 'ライター'
+    Media Creator: 'メディアクリエイター'
+    Writer: 'ライター / エディター'
+    Designer: 'デザイナー / イラストレーター'
+    Director: 'ディレクター / マーケター'
+    Other: 'その他'
   top:
     index:
       New Arrival: '新着'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   get 'oauth/:provider', to: 'oauths#oauth', :as => :auth_at_provider
 
   resources :users, only: %i[new create]
+  resources :categories, only: %i[show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get 'oauth/:provider', to: 'oauths#oauth', :as => :auth_at_provider
 
   resources :users, only: %i[new create]
-  resources :categories, only: %i[show]
+  resources :categories, only: %i[index show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   get 'oauth/:provider', to: 'oauths#oauth', :as => :auth_at_provider
 
   resources :users, only: %i[new create]
-  resources :categories, only: %i[index show]
+  resources :categories, only: %i[index show], param: :name
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ end
 
 Category.create!(name: 'Engineer')
 Category.create!(name: 'Writer')
-Category.create!(name: 'Video creator')
+Category.create!(name: 'Media creator')
 
 15.times do |index|
   Post.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ end
 
 Category.create!(name: 'Engineer')
 Category.create!(name: 'Writer')
-Category.create!(name: 'Media creator')
+Category.create!(name: 'MediaCreator')
 
 15.times do |index|
   Post.create!(

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -12,6 +12,6 @@ FactoryBot.define do
   end
 
   trait :media_creator do
-    name { 'Media Creator' }
+    name { 'MediaCreator' }
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,4 +2,16 @@ FactoryBot.define do
   factory :category do
     sequence(:name) { |n| "test_name_#{n}" }
   end
+
+  trait :engineer do
+    name { 'Engineer' }
+  end
+
+  trait :writer do
+    name { 'Writer' }
+  end
+
+  trait :video_creator do
+    name { 'Video Creator' }
+  end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     name { 'Writer' }
   end
 
-  trait :video_creator do
-    name { 'Video Creator' }
+  trait :media_creator do
+    name { 'Media Creator' }
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -5,20 +5,20 @@ FactoryBot.define do
   end
 
   trait :with_engineer do
-    after(:create) do |post|
-      create(:post_category, post: post, category: create(:category, :engineer))
+    after(:build) do |post|
+      post.categories << create(:category, :engineer)
     end
   end
 
   trait :with_writer do
-    after(:create) do |post|
-      create(:post_category, post: post, category: create(:category, :writer))
+    after(:build) do |post|
+      post.categories << create(:category, :writer)
     end
   end
 
   trait :with_videocreator do
-    after(:create) do |post|
-      create(:post_category, post: post, category: create(:category, :video_creator))
+    after(:build) do |post|
+      post.categories << create(:category, :video_creator)
     end
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -3,4 +3,22 @@ FactoryBot.define do
     sequence(:body) { |n| "test_body_#{n}" }
     association :user
   end
+
+  trait :with_engineer do
+    after(:create) do |post|
+      create(:post_category, post: post, category: create(:category, :engineer))
+    end
+  end
+
+  trait :with_writer do
+    after(:create) do |post|
+      create(:post_category, post: post, category: create(:category, :writer))
+    end
+  end
+
+  trait :with_videocreator do
+    after(:create) do |post|
+      create(:post_category, post: post, category: create(:category, :video_creator))
+    end
+  end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -16,9 +16,9 @@ FactoryBot.define do
     end
   end
 
-  trait :with_videocreator do
+  trait :with_mediacreator do
     after(:build) do |post|
-      post.categories << create(:category, :video_creator)
+      post.categories << create(:category, :media_creator)
     end
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -3,13 +3,4 @@ FactoryBot.define do
     sequence(:body) { |n| "test_body_#{n}" }
     association :user
   end
-
-  trait :with_category do
-    transient do
-      sequence(:category_name) { |n| "test_category_name_#{n}" }
-    end
-    after(:build) do |post, evaluator|
-      post.categories << build(:category, name: evaluator.category_name)
-    end
-  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name { 'test' }
+    sequence(:name) { |n| "test_#{n}" }
     sequence(:email) { |n| "test_#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "Posts", type: :system do
-  describe "トップページの表示" do
-    let!(:post_with_engineer) { create(:post, :with_engineer) }
-    let!(:post_with_writer) { create(:post, :with_writer) }
-    let!(:post_with_videocreator) { create(:post, :with_videocreator) }
+  let!(:post_with_engineer) { create(:post, :with_engineer) }
+  let!(:post_with_writer) { create(:post, :with_writer) }
+  let!(:post_with_videocreator) { create(:post, :with_videocreator) }
 
+  describe "トップページの表示" do
     context "新着の表示" do
       it '最新の投稿が表示される' do
         visit root_path
@@ -45,9 +45,17 @@ RSpec.describe "Posts", type: :system do
   end
 
   describe "カテゴリ別一覧の表示" do
+    context "全カテゴリ一覧ページ" do
+      it "投稿一覧が表示される" do
+        visit categories_path
+        expect(page).to have_content(post_with_engineer.user.name)
+        expect(page).to have_content(post_with_writer.user.name)
+        expect(page).to have_content(post_with_videocreator.user.name)
+      end
+    end
     context "エンジニアのページ" do
       it "投稿一覧が表示される" do
-        visit category_path(category.engineers)
+        visit category_path(post_with_engineer.category_ids)
         expect(page).to have_content(post_with_engineer.user.name)
         expect(page).not_to have_content(post_with_writer.user.name)
         expect(page).not_to have_content(post_with_videocreator.user.name)
@@ -55,7 +63,7 @@ RSpec.describe "Posts", type: :system do
     end
     context "ライターのページ" do
       it "投稿一覧が表示される" do
-        visit category_path(category.writers)
+        visit category_path(post_with_writer.category_ids)
         expect(page).to have_content(post_with_writer.user.name)
         expect(page).not_to have_content(post_with_engineer.user.name)
         expect(page).not_to have_content(post_with_videocreator.user.name)
@@ -63,7 +71,7 @@ RSpec.describe "Posts", type: :system do
     end
     context "動画系クリエイター" do
       it "投稿一覧が表示される" do
-        visit category_path(category.video_creators)
+        visit category_path(post_with_videocreator.category_ids)
         expect(page).to have_content(post_with_videocreator.user.name)
         expect(page).not_to have_content(post_with_engineer.user.name)
         expect(page).not_to have_content(post_with_writer.user.name)

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -3,16 +3,16 @@ require 'rails_helper'
 RSpec.describe "Posts", type: :system do
   let!(:post_with_engineer) { create(:post, :with_engineer) }
   let!(:post_with_writer) { create(:post, :with_writer) }
-  let!(:post_with_videocreator) { create(:post, :with_videocreator) }
+  let!(:post_with_mediacreator) { create(:post, :with_mediacreator) }
 
   describe "トップページの表示" do
     context "新着の表示" do
       it '最新の投稿が表示される' do
         visit root_path
         within('.new_arrival') do
-          expect(page).to have_content(post_with_engineer.user.name)
-          expect(page).to have_content(post_with_writer.user.name)
-          expect(page).to have_content(post_with_videocreator.user.name)
+          expect(page).to have_selector("#post-id-#{post_with_engineer.id}")
+          expect(page).to have_selector("#post-id-#{post_with_writer.id}")
+          expect(page).to have_selector("#post-id-#{post_with_mediacreator.id}")
         end
       end
     end
@@ -20,25 +20,25 @@ RSpec.describe "Posts", type: :system do
       it "エンジニアの投稿が表示される" do
         visit root_path
         within('.post_engineer') do
-          expect(page).to have_content(post_with_engineer.user.name)
-          expect(page).not_to have_content(post_with_writer.user.name)
-          expect(page).not_to have_content(post_with_videocreator.user.name)
+          expect(page).to have_selector("#post-id-#{post_with_engineer.id}")
+          expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")
+          expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")
         end
       end
       it "ライターの投稿が表示される" do
         visit root_path
         within('.post_writer') do
-          expect(page).to have_content(post_with_writer.user.name)
-          expect(page).not_to have_content(post_with_engineer.user.name)
-          expect(page).not_to have_content(post_with_videocreator.user.name)
+          expect(page).to have_selector("#post-id-#{post_with_writer.id}")
+          expect(page).not_to have_selector("#post-id-#{post_with_engineer.id}")
+          expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")
         end
       end
       it "動画系クリエイターの投稿が表示される" do
         visit root_path
-        within('.post_videocreator') do
-          expect(page).to have_content(post_with_videocreator.user.name)
-          expect(page).not_to have_content(post_with_engineer.user.name)
-          expect(page).not_to have_content(post_with_writer.user.name)
+        within('.post_mediacreator') do
+          expect(page).to have_selector("#post-id-#{post_with_mediacreator.id}")
+          expect(page).not_to have_selector("#post-id-#{post_with_engineer.id}")
+          expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")
         end
       end
     end
@@ -48,33 +48,33 @@ RSpec.describe "Posts", type: :system do
     context "全カテゴリ一覧ページ" do
       it "投稿一覧が表示される" do
         visit categories_path
-        expect(page).to have_content(post_with_engineer.user.name)
-        expect(page).to have_content(post_with_writer.user.name)
-        expect(page).to have_content(post_with_videocreator.user.name)
+        expect(page).to have_selector("#post-id-#{post_with_engineer.id}")
+        expect(page).to have_selector("#post-id-#{post_with_writer.id}")
+        expect(page).to have_selector("#post-id-#{post_with_mediacreator.id}")
       end
     end
     context "エンジニアのページ" do
       it "投稿一覧が表示される" do
-        visit category_path(post_with_engineer.category_ids)
-        expect(page).to have_content(post_with_engineer.user.name)
-        expect(page).not_to have_content(post_with_writer.user.name)
-        expect(page).not_to have_content(post_with_videocreator.user.name)
+        visit category_path(post_with_engineer.categories.name)
+        expect(page).to have_selector("#post-id-#{post_with_engineer.id}")
+        expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")
+        expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")
       end
     end
     context "ライターのページ" do
       it "投稿一覧が表示される" do
-        visit category_path(post_with_writer.category_ids)
-        expect(page).to have_content(post_with_writer.user.name)
-        expect(page).not_to have_content(post_with_engineer.user.name)
-        expect(page).not_to have_content(post_with_videocreator.user.name)
+        visit category_path(post_with_writer.categories.name)
+        expect(page).to have_selector("#post-id-#{post_with_writer.id}")
+        expect(page).not_to have_selector("#post-id-#{post_with_engineer.id}")
+        expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")
       end
     end
     context "動画系クリエイター" do
       it "投稿一覧が表示される" do
-        visit category_path(post_with_videocreator.category_ids)
-        expect(page).to have_content(post_with_videocreator.user.name)
-        expect(page).not_to have_content(post_with_engineer.user.name)
-        expect(page).not_to have_content(post_with_writer.user.name)
+        visit category_path(post_with_mediacreator.categories.name)
+        expect(page).to have_selector("#post-id-#{post_with_mediacreator.id}")
+        expect(page).not_to have_selector("#post-id-#{post_with_engineer.id}")
+        expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")
       end
     end
   end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -2,23 +2,17 @@ require 'rails_helper'
 
 RSpec.describe "Posts", type: :system do
   describe "トップページの表示" do
-    let!(:post1) { create(:post) }
-    let!(:post2) { create(:post) }
-    let!(:post3) { create(:post) }
-    let!(:category_engineer) { create(:category, :engineer) }
-    let!(:category_writer) { create(:category, :writer) }
-    let!(:category_videocreator) { create(:category, :video_creator) }
-    let!(:post_engineer) { create(:post_category, post: post1, category: category_engineer) }
-    let!(:post_writer) { create(:post_category, post: post2, category: category_writer) }
-    let!(:post_videocreator) { create(:post_category, post: post3, category: category_videocreator) }
+    let!(:post_with_engineer) { create(:post, :with_engineer) }
+    let!(:post_with_writer) { create(:post, :with_writer) }
+    let!(:post_with_videocreator) { create(:post, :with_videocreator) }
 
     context "新着の表示" do
       it '最新の投稿が表示される' do
         visit root_path
         within('.new_arrival') do
-          expect(page).to have_content(post_engineer.post.user.name)
-          expect(page).to have_content(post_writer.post.user.name)
-          expect(page).to have_content(post_videocreator.post.user.name)
+          expect(page).to have_content(post_with_engineer.user.name)
+          expect(page).to have_content(post_with_writer.user.name)
+          expect(page).to have_content(post_with_videocreator.user.name)
         end
       end
     end
@@ -26,22 +20,25 @@ RSpec.describe "Posts", type: :system do
       it "エンジニアの投稿が表示される" do
         visit root_path
         within('.post_engineer') do
-          expect(page).to have_content(post_engineer.post.user.name)
+          expect(page).to have_content(post_with_engineer.user.name)
         end
       end
       it "ライターの投稿が表示される" do
         visit root_path
         within('.post_writer') do
-          expect(page).to have_content(post_writer.post.user.name)
+          expect(page).to have_content(post_with_writer.user.name)
         end
       end
       it "動画系クリエイターの投稿が表示される" do
         visit root_path
         within('.post_videocreator') do
-          expect(page).to have_content(post_videocreator.post.user.name)
+          expect(page).to have_content(post_with_videocreator.user.name)
         end
       end
     end
+  end
+  describe "カテゴリ別一覧の表示" do
+    
   end
   
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -55,8 +55,7 @@ RSpec.describe "Posts", type: :system do
     end
     context "エンジニアのページ" do
       it "投稿一覧が表示される" do
-        visit category_path(post_with_engineer.categories.name)
-        sleep 3
+        visit category_path('Engineer')
         expect(page).to have_selector("#post-id-#{post_with_engineer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")
@@ -64,7 +63,7 @@ RSpec.describe "Posts", type: :system do
     end
     context "ライターのページ" do
       it "投稿一覧が表示される" do
-        visit category_path(post_with_writer.categories.name)
+        visit category_path('Writer')
         expect(page).to have_selector("#post-id-#{post_with_writer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_engineer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")
@@ -72,7 +71,7 @@ RSpec.describe "Posts", type: :system do
     end
     context "動画系クリエイター" do
       it "投稿一覧が表示される" do
-        visit category_path(post_with_mediacreator.categories.name)
+        visit category_path('MediaCreator')
         expect(page).to have_selector("#post-id-#{post_with_mediacreator.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_engineer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe "Posts", type: :system do
     context "エンジニアのページ" do
       it "投稿一覧が表示される" do
         visit category_path(post_with_engineer.categories.name)
+        sleep 3
         expect(page).to have_selector("#post-id-#{post_with_engineer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_writer.id}")
         expect(page).not_to have_selector("#post-id-#{post_with_mediacreator.id}")

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -2,17 +2,23 @@ require 'rails_helper'
 
 RSpec.describe "Posts", type: :system do
   describe "トップページの表示" do
-    let!(:post_engineer) { create(:post, :with_category, category_name: 'Engineer') }
-    let!(:post_writer) { create(:post, :with_category, category_name: 'Writer') }
-    let!(:post_videocreator) { create(:post, :with_category, category_name: 'Video Creator') }
+    let!(:post1) { create(:post) }
+    let!(:post2) { create(:post) }
+    let!(:post3) { create(:post) }
+    let!(:category_engineer) { create(:category, :engineer) }
+    let!(:category_writer) { create(:category, :writer) }
+    let!(:category_videocreator) { create(:category, :video_creator) }
+    let!(:post_engineer) { create(:post_category, post: post1, category: category_engineer) }
+    let!(:post_writer) { create(:post_category, post: post2, category: category_writer) }
+    let!(:post_videocreator) { create(:post_category, post: post3, category: category_videocreator) }
 
     context "新着の表示" do
       it '最新の投稿が表示される' do
         visit root_path
         within('.new_arrival') do
-          expect(page).to have_content(post_engineer.user.name)
-          expect(page).to have_content(post_writer.user.name)
-          expect(page).to have_content(post_videocreator.user.name)
+          expect(page).to have_content(post_engineer.post.user.name)
+          expect(page).to have_content(post_writer.post.user.name)
+          expect(page).to have_content(post_videocreator.post.user.name)
         end
       end
     end
@@ -20,19 +26,19 @@ RSpec.describe "Posts", type: :system do
       it "エンジニアの投稿が表示される" do
         visit root_path
         within('.post_engineer') do
-          expect(page).to have_content(post_engineer.user.name)
+          expect(page).to have_content(post_engineer.post.user.name)
         end
       end
       it "ライターの投稿が表示される" do
         visit root_path
         within('.post_writer') do
-          expect(page).to have_content(post_writer.user.name)
+          expect(page).to have_content(post_writer.post.user.name)
         end
       end
       it "動画系クリエイターの投稿が表示される" do
         visit root_path
         within('.post_videocreator') do
-          expect(page).to have_content(post_videocreator.user.name)
+          expect(page).to have_content(post_videocreator.post.user.name)
         end
       end
     end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -21,24 +21,54 @@ RSpec.describe "Posts", type: :system do
         visit root_path
         within('.post_engineer') do
           expect(page).to have_content(post_with_engineer.user.name)
+          expect(page).not_to have_content(post_with_writer.user.name)
+          expect(page).not_to have_content(post_with_videocreator.user.name)
         end
       end
       it "ライターの投稿が表示される" do
         visit root_path
         within('.post_writer') do
           expect(page).to have_content(post_with_writer.user.name)
+          expect(page).not_to have_content(post_with_engineer.user.name)
+          expect(page).not_to have_content(post_with_videocreator.user.name)
         end
       end
       it "動画系クリエイターの投稿が表示される" do
         visit root_path
         within('.post_videocreator') do
           expect(page).to have_content(post_with_videocreator.user.name)
+          expect(page).not_to have_content(post_with_engineer.user.name)
+          expect(page).not_to have_content(post_with_writer.user.name)
         end
       end
     end
   end
+
   describe "カテゴリ別一覧の表示" do
-    
+    context "エンジニアのページ" do
+      it "投稿一覧が表示される" do
+        visit category_path(category.engineers)
+        expect(page).to have_content(post_with_engineer.user.name)
+        expect(page).not_to have_content(post_with_writer.user.name)
+        expect(page).not_to have_content(post_with_videocreator.user.name)
+      end
+    end
+    context "ライターのページ" do
+      it "投稿一覧が表示される" do
+        visit category_path(category.writers)
+        expect(page).to have_content(post_with_writer.user.name)
+        expect(page).not_to have_content(post_with_engineer.user.name)
+        expect(page).not_to have_content(post_with_videocreator.user.name)
+      end
+    end
+    context "動画系クリエイター" do
+      it "投稿一覧が表示される" do
+        visit category_path(category.video_creators)
+        expect(page).to have_content(post_with_videocreator.user.name)
+        expect(page).not_to have_content(post_with_engineer.user.name)
+        expect(page).not_to have_content(post_with_writer.user.name)
+      end
+    end
   end
   
 end


### PR DESCRIPTION
## 概要

カテゴリ別の一覧表示
- Categoriesコントローラで投稿取得の変数を定義
- ``categories#index`` に全投稿一覧, ``categories#show`` にカテゴリ別の一覧を表示
- ルーティングの追加と``to_params``の設定

トップページ部分の投稿取得クエリの変更
- 何のカテゴリを取得するか分かりやすくするため、``PostCategory.where(category_id: )``から``Category.find_by(name: '').post_categories``に変更

Closed #7 

## 確認方法

1. ``spec/system/posts_spec.rb``のテストが正しいか
2. ``categories#index`` に全投稿が表示されているか
3. ``categories#show`` にカテゴリ別の投稿が表示されているか
4. ``categories#show`` のURLがidではなくカテゴリ名で表示されているか

## コメント

- ``categories#show``でカテゴリページ別に変数を使ってタイトル等を表示しているが、もっといいコードの記述方法があるのではと感じている
- RSpecで同カテゴリーの投稿を``create_list``を使って複数作成したいが、``category.name``のバリデーションに引っ掛かり作成できないので、どうすればいいか
