### PR TITLE
Fix: FormObjectの修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,7 +17,7 @@ class PostsController < ApplicationController
 
   def create
     @form = PostsForm.new(post_params)
-    
+
     if @form.save
       redirect_to posts_path, success: t('defaults.message.created', item: Post.model_name.human)
     else
@@ -35,7 +35,7 @@ class PostsController < ApplicationController
   def post_params
     params.require(:posts_form).permit(
       :body,
-      { images: [] }, 
+      { images: [] },
       { category_ids: [] }
     ).merge(user_id: current_user.id)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -37,7 +37,7 @@ class PostsController < ApplicationController
       :body,
       :image,
       :caption,
-      { categories: [] }
+      { category_ids: [] }
     ).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,9 +18,6 @@ class PostsController < ApplicationController
   def create
     @form = PostsForm.new(post_params)
     
-    binding.pry
-    
-
     if @form.save
       redirect_to posts_path, success: t('defaults.message.created', item: Post.model_name.human)
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,9 @@ class PostsController < ApplicationController
 
   def create
     @form = PostsForm.new(post_params)
+    
+    binding.pry
+    
 
     if @form.save
       redirect_to posts_path, success: t('defaults.message.created', item: Post.model_name.human)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,8 +35,7 @@ class PostsController < ApplicationController
   def post_params
     params.require(:posts_form).permit(
       :body,
-      :image,
-      :caption,
+      { images: [] }, 
       { category_ids: [] }
     ).merge(user_id: current_user.id)
   end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -23,15 +23,17 @@ class PostsForm
   def save
     return false if invalid?
 
-    post = Post.new(post_params)
-    post.save!
+    @form.transaction do
+      post = Post.new(post_params)
+      post.save!
 
-    images.each do |image|
-      post.post_images.create!(image: image)
-    end
+      images.each do |image|
+        post.post_images.create!(image: image)
+      end
 
-    category_ids.each do |category_id|
-      post.post_categories.create!(category_id: category_id)
+      category_ids.each do |category_id|
+        post.post_categories.create!(category_id: category_id)
+      end
     end
 
     post

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -13,6 +13,9 @@ class PostsForm
   validates :images, presence: :true
   validates :category_ids, presence: :true
 
+  validate :image_content_type
+  validate :image_size
+
   def initialize(params = {})
     super(params)
   end
@@ -41,5 +44,23 @@ class PostsForm
       body: body,
       user_id: user_id
     }
+  end
+
+  def image_content_type
+    extension_whitelist = %w[image/jpg image/jpeg image/png]
+
+    images.each do |image|
+      unless extension_whitelist.include?(image.content_type)
+        errors.add(:images, 'は許可されていないファイルの拡張子です')
+      end
+    end
+  end
+
+  def image_size
+    images.each do |image|
+      if image.size > 5.megabytes
+        errors.add(:images, 'は5MB以下のファイルまでアップロードできます')
+      end
+    end
   end
 end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -10,8 +10,8 @@ class PostsForm
   attribute :category_ids
   attribute :user_id, :integer
 
-  validates :images, presence: :true
-  validates :category_ids, presence: :true
+  validates :images, presence: true
+  validates :category_ids, presence: true
 
   validate :image_content_type
   validate :image_size

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -8,10 +8,10 @@ class PostsForm
   attribute :body, :string
   attribute :image, :string
   attribute :caption, :string
-  attribute :categories
+  attribute :category_ids
   attribute :user_id, :integer
 
-  validates :image, :categories, presence: :true
+  validates :image, :category_ids, presence: :true
 
   def initialize(params = {})
     super(params)
@@ -22,11 +22,10 @@ class PostsForm
 
     post = Post.new(post_params)
 
-    # 画像の複数登録仕様にはなっていない
     post.post_images.build(post_images_params).save!
 
-    categories.each do |category|
-      post.post_categories.build(category_id: category).save!
+    category_ids.each do |category_id|
+      post.post_categories.build(category_id: category_id).save!
     end
 
     post.save ? true : false

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -47,6 +47,8 @@ class PostsForm
   end
 
   def image_content_type
+    return false if images.blank?
+    
     extension_whitelist = %w[image/jpg image/jpeg image/png]
 
     images.each do |image|
@@ -57,6 +59,8 @@ class PostsForm
   end
 
   def image_size
+    return false if images.blank?
+
     images.each do |image|
       if image.size > 5.megabytes
         errors.add(:images, 'は5MB以下のファイルまでアップロードできます')

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -16,15 +16,12 @@ class PostsForm
   validate :image_content_type
   validate :image_size
 
-  def initialize(params = {})
-    super(params)
-  end
-
   def save
     return false if invalid?
 
+    post = Post.new(post_params)
+
     ActiveRecord::Base.transaction do
-      post = Post.new(post_params)
       post.save!
 
       images.each do |image|
@@ -35,6 +32,8 @@ class PostsForm
         post.post_categories.create!(category_id: category_id)
       end
     end
+
+    post
   end
 
   private

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -23,7 +23,7 @@ class PostsForm
   def save
     return false if invalid?
 
-    @form.transaction do
+    ActiveRecord::Base.transaction do
       post = Post.new(post_params)
       post.save!
 
@@ -35,8 +35,6 @@ class PostsForm
         post.post_categories.create!(category_id: category_id)
       end
     end
-
-    post
   end
 
   private

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -51,7 +51,7 @@ class PostsForm
 
     images.each do |image|
       unless extension_whitelist.include?(image.content_type)
-        errors.add(:images, 'は許可されていないファイルの拡張子です')
+        errors.add(:images, 'は jpg/jpeg/png が許可されています')
       end
     end
   end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -6,12 +6,12 @@ class PostsForm
   mount_uploader :image, PostImageUploader
 
   attribute :body, :string
-  attribute :image, :string
-  attribute :caption, :string
+  attribute :images
   attribute :category_ids
   attribute :user_id, :integer
 
-  validates :image, :category_ids, presence: :true
+  validates :images, presence: :true
+  validates :category_ids, presence: :true
 
   def initialize(params = {})
     super(params)
@@ -21,14 +21,17 @@ class PostsForm
     return false if invalid?
 
     post = Post.new(post_params)
+    post.save!
 
-    post.post_images.build(post_images_params).save!
-
-    category_ids.each do |category_id|
-      post.post_categories.build(category_id: category_id).save!
+    images.each do |image|
+      post.post_images.create!(image: image)
     end
 
-    post.save ? true : false
+    category_ids.each do |category_id|
+      post.post_categories.create!(category_id: category_id)
+    end
+
+    post
   end
 
   private
@@ -37,13 +40,6 @@ class PostsForm
     {
       body: body,
       user_id: user_id
-    }
-  end
-
-  def post_images_params
-    {
-      image: image,
-      caption: caption
     }
   end
 end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -48,13 +48,11 @@ class PostsForm
 
   def image_content_type
     return false if images.blank?
-    
+
     extension_whitelist = %w[image/jpg image/jpeg image/png]
 
     images.each do |image|
-      unless extension_whitelist.include?(image.content_type)
-        errors.add(:images, 'は jpg/jpeg/png が許可されています')
-      end
+      errors.add(:images, 'は jpg/jpeg/png が許可されています') unless extension_whitelist.include?(image.content_type)
     end
   end
 
@@ -62,9 +60,7 @@ class PostsForm
     return false if images.blank?
 
     images.each do |image|
-      if image.size > 5.megabytes
-        errors.add(:images, 'は5MB以下のファイルまでアップロードできます')
-      end
+      errors.add(:images, 'は5MB以下のファイルまでアップロードできます') if image.size > 5.megabytes
     end
   end
 end

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,10 +1,9 @@
 .box.box-primary
   = simple_form_for @form, url: posts_path do |f|
     .box-body
-      = f.input :image, as: :file
-      = f.input :caption, placeholder: '写っているアイテムの説明や使用感など'
+      = f.input :images, as: :file, input_html: { multiple: true }
 
-      = f.input :body, as: :text, placeholder: '推しポイントや今後取り入れたいアイテムなどあれば紹介しよう'
+      = f.input :body, as: :text
 
       = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -6,7 +6,7 @@
 
       = f.input :body, as: :text, placeholder: '推しポイントや今後取り入れたいアイテムなどあれば紹介しよう'
 
-      = f.input :categories, as: :check_boxes, collection: Category.all, include_hidden: false
+      = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 
     .box-footer
       = f.button :submit, '投稿する', class: %w[btn btn-primary]

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -2,5 +2,5 @@ ja:
   activemodel:
     attributes:
       posts_form:
-        image: '画像'
-        categories: 'カテゴリー'
+        images: '画像'
+        category_ids: 'カテゴリー'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,78 +10,77 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_06_163207) do
-
-  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "uid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+ActiveRecord::Schema.define(version: 20_210_306_163_207) do
+  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'uid', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true
+  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['name'], name: 'index_categories_on_name', unique: true
   end
 
-  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body", null: false
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body', null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_comments_on_post_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "category_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
-    t.index ["category_id"], name: "index_post_categories_on_category_id"
-    t.index ["post_id"], name: "index_post_categories_on_post_id"
+  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'category_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
+    t.index ['category_id'], name: 'index_post_categories_on_category_id'
+    t.index ['post_id'], name: 'index_post_categories_on_post_id'
   end
 
-  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "image", null: false
-    t.string "caption"
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_post_images_on_post_id"
+  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'image', null: false
+    t.string 'caption'
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_post_images_on_post_id'
   end
 
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body"
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_posts_on_user_id"
+  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['user_id'], name: 'index_posts_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name", null: false
-    t.text "description"
-    t.string "image"
-    t.integer "role", default: 0, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name', null: false
+    t.text 'description'
+    t.string 'image'
+    t.integer 'role', default: 0, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
 
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
-  add_foreign_key "post_categories", "categories"
-  add_foreign_key "post_categories", "posts"
-  add_foreign_key "post_images", "posts"
-  add_foreign_key "posts", "users"
+  add_foreign_key 'comments', 'posts'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'post_categories', 'categories'
+  add_foreign_key 'post_categories', 'posts'
+  add_foreign_key 'post_images', 'posts'
+  add_foreign_key 'posts', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,77 +10,78 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_306_163_207) do
-  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+ActiveRecord::Schema.define(version: 2021_03_06_163207) do
+
+  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['name'], name: 'index_categories_on_name', unique: true
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'category_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'image', null: false
-    t.string 'caption'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_post_images_on_post_id'
+  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "image", null: false
+    t.string "caption"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', null: false
-    t.text 'description'
-    t.string 'image'
-    t.integer 'role', default: 0, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "image"
+    t.integer "role", default: 0, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'post_images', 'posts'
-  add_foreign_key 'posts', 'users'
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "post_images", "posts"
+  add_foreign_key "posts", "users"
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Posts', type: :system do
   include CarrierWave::Test::Matchers
   before do
-    #driven_by(:rack_test)
+    driven_by(:rack_test)
   end
 
   describe '投稿のCRUD' do


### PR DESCRIPTION
## 概要

投稿機能のFormObjectの記述を修正

## 確認方法

1. 投稿機能が正しく機能しているか

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした
- [ ] specテストをパスした

## コメント

- FormObject内の記述が冗長だったためリファクタリング
- 修正後の解説をQiitaに投稿済み
[【Rails】FormObject を使って、複数のテーブル情報を同時保存 - Qiita](https://qiita.com/en-Barry/items/95044b80073884d960ff)