### PR TITLE
Add: Postテーブルにareaカラムを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'carrierwave', '2.1.1'
 # Storage
 gem 'mini_magick', '4.11.0'
 
+# Model
+gem 'enum_help'
+
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     crass (1.0.6)
     debug_inspector (1.0.0)
     diff-lcs (1.4.4)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -380,6 +382,7 @@ DEPENDENCIES
   byebug
   capybara
   carrierwave (= 2.1.1)
+  enum_help
   factory_bot_rails (~> 6.1.0)
   faker
   font-awesome-sass

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -56,6 +56,7 @@ class PostsController < ApplicationController
   def post_params
     params.require(:post).permit(
       :body,
+      :type,
       { images: [] },
       { category_ids: [] }
     ).merge(user_id: current_user.id)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -56,7 +56,7 @@ class PostsController < ApplicationController
   def post_params
     params.require(:post).permit(
       :body,
-      :type,
+      :area,
       { images: [] },
       { category_ids: [] }
     ).merge(user_id: current_user.id)

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -6,7 +6,7 @@ class PostsForm
   mount_uploader :image, PostImageUploader
 
   attribute :body, :string
-  attribute :type, :integer
+  attribute :area, :integer
   attribute :images
   attribute :category_ids
   attribute :user_id, :integer
@@ -64,7 +64,7 @@ class PostsForm
   def post_params
     {
       body: body,
-      type: type,
+      area: area,
       user_id: user_id
     }
   end
@@ -72,6 +72,7 @@ class PostsForm
   def default_attributes
     {
       body: @post.body,
+      area: @post.area,
       user_id: @post.user_id,
       images: @post.post_images.map(&:image),
       category_ids: @post.post_categories

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -6,6 +6,7 @@ class PostsForm
   mount_uploader :image, PostImageUploader
 
   attribute :body, :string
+  attribute :type, :integer
   attribute :images
   attribute :category_ids
   attribute :user_id, :integer
@@ -63,6 +64,7 @@ class PostsForm
   def post_params
     {
       body: body,
+      type: type,
       user_id: user_id
     }
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,4 +4,6 @@ class Post < ApplicationRecord
   has_many :post_images, dependent: :destroy
   has_many :comments, dependent: :destroy
   belongs_to :user
+
+  enum role: { around: 0, focus: 1 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,5 +5,5 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   belongs_to :user
 
-  enum role: { around: 0, focus: 1 }
+  enum area: { around: 0, focus: 1 }
 end

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -5,7 +5,7 @@
 
       = f.input :body, as: :text
 
-      = f.select :area, Post.areas.keys
+      = f.select :area, Post.areas_i18n.invert
 
       = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -5,6 +5,8 @@
 
       = f.input :body, as: :text
 
+      = f.input :type
+
       = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 
     .box-footer

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -5,7 +5,7 @@
 
       = f.input :body, as: :text
 
-      = f.input :type
+      = f.select :area, Post.areas.keys
 
       = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -5,7 +5,7 @@
 
       = f.input :body, as: :text
 
-      = f.select :area, Post.areas_i18n.invert
+      = f.input :area, as: :select, collection: Post.areas_i18n.invert
 
       = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -12,6 +12,8 @@
 
         = f.input :body, as: :text
 
+        = f.select :area, Post.areas_i18n.invert
+
         = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 
       .box-footer

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -12,7 +12,7 @@
 
         = f.input :body, as: :text
 
-        = f.select :area, Post.areas_i18n.invert
+        = f.input :area, as: :select, collection: Post.areas_i18n.invert
 
         = f.input :category_ids, as: :check_boxes, collection: Category.all, include_hidden: false
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -18,6 +18,7 @@ ja:
         role: 'タイプ'
       post:
         body: '本文'
+        area: 'ジャンル'
         images: '画像'
         category_ids: 'カテゴリー'
       comment:

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  enums:
+    post:
+      area:
+        around: 'デスク全体'
+        focus: '特定の箇所やアイテム'

--- a/db/migrate/20210319033225_add_type_to_post.rb
+++ b/db/migrate/20210319033225_add_type_to_post.rb
@@ -1,0 +1,5 @@
+class AddTypeToPost < ActiveRecord::Migration[6.0]
+  def change
+    add_column :posts, :type, :integer, default: 0
+  end
+end

--- a/db/migrate/20210319035403_rename_type_column_to_posts.rb
+++ b/db/migrate/20210319035403_rename_type_column_to_posts.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToPosts < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :posts, :type, :area
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,77 +10,79 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_306_163_207) do
-  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+ActiveRecord::Schema.define(version: 2021_03_19_033225) do
+
+  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['name'], name: 'index_categories_on_name', unique: true
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'category_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'image', null: false
-    t.string 'caption'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_post_images_on_post_id'
+  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "image", null: false
+    t.string "caption"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "type", default: 0
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', null: false
-    t.text 'description'
-    t.string 'image'
-    t.integer 'role', default: 0, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "image"
+    t.integer "role", default: 0, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'post_images', 'posts'
-  add_foreign_key 'posts', 'users'
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "post_images", "posts"
+  add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,79 +10,78 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_19_035403) do
-
-  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "uid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+ActiveRecord::Schema.define(version: 20_210_319_035_403) do
+  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'uid', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true
+  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['name'], name: 'index_categories_on_name', unique: true
   end
 
-  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body", null: false
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body', null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_comments_on_post_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "category_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
-    t.index ["category_id"], name: "index_post_categories_on_category_id"
-    t.index ["post_id"], name: "index_post_categories_on_post_id"
+  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'category_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
+    t.index ['category_id'], name: 'index_post_categories_on_category_id'
+    t.index ['post_id'], name: 'index_post_categories_on_post_id'
   end
 
-  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "image", null: false
-    t.string "caption"
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_post_images_on_post_id"
+  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'image', null: false
+    t.string 'caption'
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_post_images_on_post_id'
   end
 
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body"
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "area", default: 0
-    t.index ["user_id"], name: "index_posts_on_user_id"
+  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'area', default: 0
+    t.index ['user_id'], name: 'index_posts_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name", null: false
-    t.text "description"
-    t.string "image"
-    t.integer "role", default: 0, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name', null: false
+    t.text 'description'
+    t.string 'image'
+    t.integer 'role', default: 0, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
 
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
-  add_foreign_key "post_categories", "categories"
-  add_foreign_key "post_categories", "posts"
-  add_foreign_key "post_images", "posts"
-  add_foreign_key "posts", "users"
+  add_foreign_key 'comments', 'posts'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'post_categories', 'categories'
+  add_foreign_key 'post_categories', 'posts'
+  add_foreign_key 'post_images', 'posts'
+  add_foreign_key 'posts', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_19_033225) do
+ActiveRecord::Schema.define(version: 2021_03_19_035403) do
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2021_03_19_033225) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "type", default: 0
+    t.integer "area", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
## 概要

Postテーブルにareaカラムを追加
- 投稿のジャンルを判別するためのカラムを追加

Closed #38 

## 確認方法

1. 新規投稿・編集時に投稿のジャンルを選択できるか

## 影響範囲

- 新規投稿ページ
- 投稿編集ページ

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした
- [ ] specテストをパスした

## コメント