### PR TITLE
Add: 管理画面にユーザーとアイテムのCRUD機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,11 +44,14 @@ gem 'mini_magick', '4.11.0'
 # Model
 gem 'enum_help'
 
-# アイテム情報取得API
+# 外部API
 gem 'rakuten_web_service'
 
 # SEO/OGP対策
 gem 'meta-tags'
+
+# Search
+gem 'ransack'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,10 @@ GEM
     rake (13.0.3)
     rakuten_web_service (1.13.0)
       json (~> 2.3)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -418,6 +422,7 @@ DEPENDENCIES
   rails-i18n (>= 5.1.3)
   rails_best_practices
   rakuten_web_service
+  ransack
   redis-rails
   rspec-rails (~> 4.0.1)
   rubocop

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -2,7 +2,8 @@ class Admin::ItemsController < Admin::BaseController
   before_action :set_item, only: %i[show edit update destroy]
 
   def index
-    @items = Item.all
+    @search = Item.ransack(params[:q])
+    @items = @search.result(distinct: true).page(params[:page])
   end
 
   def new

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -3,7 +3,7 @@ class Admin::ItemsController < Admin::BaseController
 
   def index
     @search = Item.ransack(params[:q])
-    @items = @search.result(distinct: true).page(params[:page])
+    @items = @search.result(distinct: true)
   end
 
   def new

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -42,6 +42,6 @@ class Admin::ItemsController < Admin::BaseController
   end
 
   def item_params
-
+    params.require(:item).permit(:item_code, :name, :price, :rakuten_url, :amazon_url, :image)
   end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,10 +1,47 @@
 class Admin::ItemsController < Admin::BaseController
+  before_action :set_item, only: %i[show edit update destroy]
+
   def index
+    @items = Item.all
   end
 
-  def show
+  def new
+    @item = Item.new
   end
 
-  def edit
+  def show; end
+
+  def edit; end
+
+  def create
+    @item = Item.new(user_params)
+    if @item.save
+      redirect_to admin_item_path(@item), , success: t('defaults.message.created', item: Item.model_name.human)
+    else
+      edirect_to admin_item_path(@item), danger: t('defaults.message.not_created', item: Item.model_name.human)
+    end
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to admin_item_path(@item), success: t('defaults.message.updated', item: Item.model_name.human)
+    else
+      redirect_to admin_item_path(@item), danger: t('defaults.message.not_updated', item: Item.model_name.human)
+    end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to admin_items_path, success: t('defaults.message.deleted', item: Item.model_name.human)
+  end
+
+  private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def item_params
+
   end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -16,7 +16,7 @@ class Admin::ItemsController < Admin::BaseController
   def create
     @item = Item.new(user_params)
     if @item.save
-      redirect_to admin_item_path(@item), , success: t('defaults.message.created', item: Item.model_name.human)
+      redirect_to admin_item_path(@item), success: t('defaults.message.created', item: Item.model_name.human)
     else
       edirect_to admin_item_path(@item), danger: t('defaults.message.not_created', item: Item.model_name.human)
     end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,10 @@
+class Admin::ItemsController < Admin::BaseController
+  def index
+  end
+
+  def show
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[show edit update destroy]
 
   def index
-
+    @users = User.all
   end
 
   def show; end
@@ -19,7 +19,7 @@ class Admin::UsersController < Admin::BaseController
 
   def destroy
     @user.destroy
-    redirect_to admin_root_path(@user), success: t('defaults.message.delete', item: User.model_name.human)
+    redirect_to admin_root_path(@user), success: t('defaults.message.deleted', item: User.model_name.human)
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,8 @@ class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[show edit update destroy]
 
   def index
-    @users = User.all
+    @search = User.ransack(params[:q])
+    @users = @search.result(distinct: true).page(params[:page])
   end
 
   def show; end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,7 @@ class Admin::UsersController < Admin::BaseController
 
   def index
     @search = User.ransack(params[:q])
-    @users = @search.result(distinct: true).page(params[:page])
+    @users = @search.result(distinct: true)
   end
 
   def show; end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,34 @@
+class Admin::UsersController < Admin::BaseController
+  before_action :set_user, only: %i[show edit update destroy]
+
+  def index
+
+  end
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), success: t('defaults.message.updated', item: User.model_name.human)
+    else
+      render :edit, danger: t('defaults.message.not_updated', item: User.model_name.human)
+    end
+  end
+
+  def destroy
+    @user.destroy
+    redirect_to admin_root_path(@user), success: t('defaults.message.delete', item: User.model_name.human)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :role, :password, :password_confirmation, :image, :image_cache)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,7 @@ module ApplicationHelper
     }
   end
 
+  # アイテムURLを自動的にハイパーリンク化
   def text_url_to_link(text)
     URI.extract(text, ["http", "https"]).uniq.each do |url|
       sub_text = ""

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  require "uri"
+  require 'uri'
 
   def default_meta_tags
     {
@@ -16,9 +16,9 @@ module ApplicationHelper
 
   # アイテムURLを自動的にハイパーリンク化
   def text_url_to_link(text)
-    URI.extract(text, ["http", "https"]).uniq.each do |url|
-      sub_text = ""
-      sub_text << "<a href=" << url << " target=\"_blank\">" << url << "</a>"
+    URI.extract(text, %w[http https]).uniq.each do |url|
+      sub_text = ''
+      sub_text << '<a href=' << url << ' target="_blank">' << url << '</a>'
       text.gsub!(url, sub_text)
     end
     text

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,11 @@ module ApplicationHelper
     text
   end
 
+  # アクティブ化を判断
+  def active_if(path)
+    path == controller_path ? 'active' : ''
+  end
+
   private
 
   def default_og

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  require "uri"
+
   def default_meta_tags
     {
       site: 'Buildesk（ビルデスク）',
@@ -10,6 +12,15 @@ module ApplicationHelper
         { href: image_url('buildesk_favicon.png') }
       ]
     }
+  end
+
+  def text_url_to_link(text)
+    URI.extract(text, ["http", "https"]).uniq.each do |url|
+      sub_text = ""
+      sub_text << "<a href=" << url << " target=\"_blank\">" << url << "</a>"
+      text.gsub!(url, sub_text)
+    end
+    text
   end
 
   private

--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -5,4 +5,6 @@ require("channels")
 
 require('jquery')
 require('bootstrap')
-require("admin-lte");
+require("admin-lte")
+
+require('../packs/user_edit.js')

--- a/app/javascript/packs/user_edit.js
+++ b/app/javascript/packs/user_edit.js
@@ -1,0 +1,14 @@
+$(function() {
+    function readURL(input) {
+        if (input.files && input.files[0]) {
+        var reader = new FileReader();
+        reader.onload = function (e) {
+    $('#preview').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+        }
+    }
+    $("#user_image").change(function(){
+        readURL(this);
+    });
+});

--- a/app/javascript/stylesheets/admin.scss
+++ b/app/javascript/stylesheets/admin.scss
@@ -1,2 +1,6 @@
 @import 'admin-lte/plugins/fontawesome-free/css/all.min';
 @import 'admin-lte/dist/css/adminlte.min';
+
+.active {
+  background-color: #007bff;
+}

--- a/app/uploaders/user_image_uploader.rb
+++ b/app/uploaders/user_image_uploader.rb
@@ -30,7 +30,9 @@ class UserImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Create different versions of your uploaded files:
-  process resize_to_fit: [300, 300]
+  version :thumb do
+    process resize_to_fill: [150, 150]
+  end
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/uploaders/user_image_uploader.rb
+++ b/app/uploaders/user_image_uploader.rb
@@ -30,9 +30,7 @@ class UserImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Create different versions of your uploaded files:
-  version :thumb do
-    process resize_to_fill: [100, 100]
-  end
+  process resize_to_fit: [300, 300]
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/views/admin/items/_item.html.slim
+++ b/app/views/admin/items/_item.html.slim
@@ -1,0 +1,13 @@
+tr
+  th[scope="row"]
+    = item.id
+  td
+    = link_to item.name, admin_item_path(item)
+  td
+    = item.role
+  td
+    = l(item.created_at, format: :short)
+  td
+    = link_to '編集', edit_admin_item_path(item), class: %i[btn btn-success]
+  td
+    = link_to '削除', admin_item_path(item), method: :delete, class: %i[btn btn-danger], data: { confirm: t('defaults.message.delete_confirm') }

--- a/app/views/admin/items/_item.html.slim
+++ b/app/views/admin/items/_item.html.slim
@@ -4,8 +4,6 @@ tr
   td
     = link_to item.name, admin_item_path(item)
   td
-    = item.role
-  td
     = l(item.created_at, format: :short)
   td
     = link_to '編集', edit_admin_item_path(item), class: %i[btn btn-success]

--- a/app/views/admin/items/edit.html.slim
+++ b/app/views/admin/items/edit.html.slim
@@ -1,2 +1,27 @@
-h1 Admin::Items#edit
-p Find me in app/views/admin/items/edit.html.slim
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1
+        | item#edit
+
+      .box.box-primary
+        = simple_form_for(@item, url: admin_item_path) do |f|
+          .box-body
+            = f.input :name
+
+            = f.input :price
+
+            = f.input :rakuten_url
+
+            = f.input :amazon_url
+
+            = f.input :image, as: :file, class: 'form-control mb-3', accept: 'image/*'
+            = f.hidden_field :image_cache
+            .mt-3.mb-3
+              = image_tag @item.image.url,
+                          class: 'rounded-circle',
+                          id: 'preview',
+                          size: '300x300'
+
+          .box-footer
+            = f.button :submit, class: %w[btn btn-primary]

--- a/app/views/admin/items/edit.html.slim
+++ b/app/views/admin/items/edit.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2

--- a/app/views/admin/items/edit.html.slim
+++ b/app/views/admin/items/edit.html.slim
@@ -2,7 +2,7 @@
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1
-        | item#edit
+        = t('.title')
 
       .box.box-primary
         = simple_form_for(@item, url: admin_item_path) do |f|

--- a/app/views/admin/items/edit.html.slim
+++ b/app/views/admin/items/edit.html.slim
@@ -7,6 +7,8 @@
       .box.box-primary
         = simple_form_for(@item, url: admin_item_path) do |f|
           .box-body
+            = f.input :item_code
+
             = f.input :name
 
             = f.input :price
@@ -14,14 +16,6 @@
             = f.input :rakuten_url
 
             = f.input :amazon_url
-
-            = f.input :image, as: :file, class: 'form-control mb-3', accept: 'image/*'
-            = f.hidden_field :image_cache
-            .mt-3.mb-3
-              = image_tag @item.image.url,
-                          class: 'rounded-circle',
-                          id: 'preview',
-                          size: '300x300'
 
           .box-footer
             = f.button :submit, class: %w[btn btn-primary]

--- a/app/views/admin/items/edit.html.slim
+++ b/app/views/admin/items/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Items#edit
+p Find me in app/views/admin/items/edit.html.slim

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -1,3 +1,18 @@
+.container.mb-5.pt-2
+  h1
+    = t('.title')
+  .row
+    .col-md-12.mb-3
+      = search_form_for @search, url: admin_items_path do |f|
+        .row
+          .form-inline.align-items-center.mx-auto
+            .col-auto
+              = f.search_field :item_code_cont, class: 'form-control', placeholder: '検索コード'
+            .col-auto
+              = f.search_field :name_cont, class: 'form-control', placeholder: '検索ワード'
+            .col-auto
+              = f.submit value: '検索', class: 'btn btn-primary'
+              
 table.table.table-striped
   thead
     tr
@@ -6,6 +21,6 @@ table.table.table-striped
       th[scope="col"]
         = t('activerecord.attributes.item.name')
       th[scope="col"]
-        = t('activerecord.attributes.user.created_at')
+        = t('activerecord.attributes.item.created_at')
   tbody
     = render @items

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -1,2 +1,11 @@
-h1 Admin::Items#index
-p Find me in app/views/admin/items/index.html.slim
+table.table.table-striped
+  thead
+    tr
+      th[scope="col"]
+        = 'id'
+      th[scope="col"]
+        = t('activerecord.attributes.item.name')
+      th[scope="col"]
+        = t('activerecord.attributes.user.created_at')
+  tbody
+    = render @items

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Items#index
+p Find me in app/views/admin/items/index.html.slim

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container.mb-5.pt-2
   h1
     = t('.title')

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -12,6 +12,8 @@
               = f.search_field :name_cont, class: 'form-control', placeholder: '検索ワード'
             .col-auto
               = f.submit value: '検索', class: 'btn btn-primary'
+            .col-auto
+              = link_to 'アイテム追加', new_admin_item_path, class: 'btn btn-secondary'
               
 table.table.table-striped
   thead

--- a/app/views/admin/items/new.html.slim
+++ b/app/views/admin/items/new.html.slim
@@ -2,7 +2,7 @@
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1
-        | item#new
+        = t('.title')
 
       .box.box-primary
         = simple_form_for(@item, url: admin_items_path) do |f|

--- a/app/views/admin/items/new.html.slim
+++ b/app/views/admin/items/new.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2

--- a/app/views/admin/items/new.html.slim
+++ b/app/views/admin/items/new.html.slim
@@ -1,0 +1,23 @@
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1
+        | item#new
+
+      .box.box-primary
+        = simple_form_for(@item, url: admin_items_path) do |f|
+          .box-body
+            = f.input :item_code
+
+            = f.input :name
+
+            = f.input :price
+
+            = f.input :image, placeholder: '商品画像URL'
+
+            = f.input :rakuten_url
+
+            = f.input :amazon_url
+
+          .box-footer
+            = f.button :submit, class: %w[btn btn-primary]

--- a/app/views/admin/items/show.html.slim
+++ b/app/views/admin/items/show.html.slim
@@ -27,17 +27,17 @@
             th[scope="row"]
               | 商品イメージ
             td
-              = image_tag @item.image_url, size: '300x300'
+              = image_tag @item.image, width: 300, height: 'auto'
           tr
             th[scope="row"]
               | 楽天リンク
             td
-              = @item.rakuten_url if @item.rakuten_url.present?
+              = text_url_to_link(@item.rakuten_url).html_safe if @item.rakuten_url.present?
           tr
             th[scope="row"]
               | Amazonリンク
             td
-              = @item.amazon_url if @item.amazon_url.present?
+              = text_url_to_link(@item.amazon_url).html_safe if @item.amazon_url.present?
           tr
             th[scope="row"]
               | 作成日時

--- a/app/views/admin/items/show.html.slim
+++ b/app/views/admin/items/show.html.slim
@@ -15,6 +15,11 @@
               = @item.id
           tr
             th[scope="row"]
+              | コード
+            td
+              = @item.item_code
+          tr
+            th[scope="row"]
               | 商品名
             td
               = @item.name

--- a/app/views/admin/items/show.html.slim
+++ b/app/views/admin/items/show.html.slim
@@ -2,7 +2,7 @@
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1
-        | item#show
+        = t('.title')
       .text-right.mb-3
         = link_to '編集', edit_admin_item_path(@item), class: %i[btn btn-success]
         = link_to '削除', admin_item_path(@item), method: :delete, class: %i[btn btn-danger], data: { confirm: t('defaults.message.delete_confirm') }
@@ -15,36 +15,36 @@
               = @item.id
           tr
             th[scope="row"]
-              | コード
+              = t('activerecord.attributes.item.item_code')
             td
               = @item.item_code
           tr
             th[scope="row"]
-              | 商品名
+              = t('activerecord.attributes.item.name')
             td
               = @item.name
           tr
             th[scope="row"]
-              | 価格
+              = t('activerecord.attributes.item.price')
             td
               = @item.price
           tr
             th[scope="row"]
-              | 商品イメージ
+              = t('activerecord.attributes.item.image')
             td
               = image_tag @item.image, width: 300, height: 'auto'
           tr
             th[scope="row"]
-              | 楽天リンク
+              = t('activerecord.attributes.item.rakuten_url')
             td
               = text_url_to_link(@item.rakuten_url).html_safe if @item.rakuten_url.present?
           tr
             th[scope="row"]
-              | Amazonリンク
+              = t('activerecord.attributes.item.amazon_url')
             td
               = text_url_to_link(@item.amazon_url).html_safe if @item.amazon_url.present?
           tr
             th[scope="row"]
-              | 作成日時
+              = t('activerecord.attributes.item.created_at')
             td
               = l(@item.created_at, format: :short)

--- a/app/views/admin/items/show.html.slim
+++ b/app/views/admin/items/show.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2

--- a/app/views/admin/items/show.html.slim
+++ b/app/views/admin/items/show.html.slim
@@ -1,2 +1,45 @@
-h1 Admin::Items#show
-p Find me in app/views/admin/items/show.html.slim
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1
+        | item#show
+      .text-right.mb-3
+        = link_to '編集', edit_admin_item_path(@item), class: %i[btn btn-success]
+        = link_to '削除', admin_item_path(@item), method: :delete, class: %i[btn btn-danger], data: { confirm: t('defaults.message.delete_confirm') }
+      table.table.table-bordered.bg-white
+        tbody
+          tr
+            th[scope="row"]
+              | ID
+            td
+              = @item.id
+          tr
+            th[scope="row"]
+              | 商品名
+            td
+              = @item.name
+          tr
+            th[scope="row"]
+              | 価格
+            td
+              = @item.price
+          tr
+            th[scope="row"]
+              | 商品イメージ
+            td
+              = image_tag @item.image_url, size: '300x300'
+          tr
+            th[scope="row"]
+              | 楽天リンク
+            td
+              = @item.rakuten_url if @item.rakuten_url.present?
+          tr
+            th[scope="row"]
+              | Amazonリンク
+            td
+              = @item.amazon_url if @item.amazon_url.present?
+          tr
+            th[scope="row"]
+              | 作成日時
+            td
+              = l(@item.created_at, format: :short)

--- a/app/views/admin/items/show.html.slim
+++ b/app/views/admin/items/show.html.slim
@@ -1,0 +1,2 @@
+h1 Admin::Items#show
+p Find me in app/views/admin/items/show.html.slim

--- a/app/views/admin/shared/_footer.html.slim
+++ b/app/views/admin/shared/_footer.html.slim
@@ -1,4 +1,4 @@
 footer.main-footer
   strong
-    | Copyright © Buidesk.
+    | Copyright © Buildesk.
   |  All rights reserved. 

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -13,17 +13,17 @@ aside.main-sidebar.sidebar-dark-primary.elevation-4
     nav.mt-2
       ul.nav.nav-pills.nav-sidebar.flex-column[data-widget="treeview" role="menu" data-accordion="false"]
         li.nav-item
-          = link_to admin_users_path, class: "nav-link" do
+          = link_to admin_users_path, class: "nav-link #{active_if('admin/users')}" do
             i.nav-icon.far.fa-user
             p
               |  ユーザー一覧 
         li.nav-item
-          = link_to admin_items_path, class: "nav-link" do
+          = link_to admin_items_path, class: "nav-link #{active_if('admin/items')}" do
             i.nav-icon.fas.fa-mouse
             p
               |  アイテム一覧
         li.nav-item
-          = link_to '#', class: "nav-link" do
+          = link_to '#', class: "nav-link #{active_if('admin/posts')}" do
             i.nav-icon.far.fa-file-image
             p
               |  投稿一覧

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -1,5 +1,5 @@
 aside.main-sidebar.sidebar-dark-primary.elevation-4
-  a.brand-link[href="index3.html"]
+  = link_to admin_root_path, class: 'brand-link' do
     = image_tag 'buildesk_favicon.png', class: 'brand-image img-circle elevation-3'
     span.brand-text.font-weight-light
       | Buildesk
@@ -8,7 +8,7 @@ aside.main-sidebar.sidebar-dark-primary.elevation-4
       .image
         = image_tag current_user.image_url, class: 'img-circle elevation-2'
       .info
-        a.d-block[href="#"]
+        = link_to admin_user_path(current_user), class: 'd-block' do
           = current_user.name
     nav.mt-2
       ul.nav.nav-pills.nav-sidebar.flex-column[data-widget="treeview" role="menu" data-accordion="false"]

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -6,7 +6,7 @@ aside.main-sidebar.sidebar-dark-primary.elevation-4
   .sidebar
     .user-panel.mt-3.pb-3.mb-3.d-flex
       .image
-        = image_tag current_user.image_url, class: 'img-circle elevation-2'
+        = image_tag current_user.image_url(:thumb), class: 'img-circle elevation-2'
       .info
         = link_to admin_user_path(current_user), class: 'd-block' do
           = current_user.name

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -13,7 +13,7 @@ aside.main-sidebar.sidebar-dark-primary.elevation-4
     nav.mt-2
       ul.nav.nav-pills.nav-sidebar.flex-column[data-widget="treeview" role="menu" data-accordion="false"]
         li.nav-item
-          = link_to '#', class: "nav-link" do
+          = link_to admin_users_path, class: "nav-link" do
             i.nav-icon.far.fa-user
             p
               |  ユーザー一覧 

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -18,7 +18,7 @@ aside.main-sidebar.sidebar-dark-primary.elevation-4
             p
               |  ユーザー一覧 
         li.nav-item
-          = link_to '#', class: "nav-link" do
+          = link_to admin_items_path, class: "nav-link" do
             i.nav-icon.fas.fa-mouse
             p
               |  アイテム一覧

--- a/app/views/admin/users/_user.html.slim
+++ b/app/views/admin/users/_user.html.slim
@@ -1,0 +1,13 @@
+tr
+  th[scope="row"]
+    = user.id
+  td
+    = link_to user.name, admin_user_path(user)
+  td
+    = user.role
+  td
+    = l(user.created_at, format: :short)
+  td
+    = link_to '編集', edit_admin_user_path(user), class: %i[btn btn-success]
+  td
+    = link_to '削除', admin_user_path(user), method: :delete, class: %i[btn btn-danger]

--- a/app/views/admin/users/_user.html.slim
+++ b/app/views/admin/users/_user.html.slim
@@ -10,4 +10,4 @@ tr
   td
     = link_to '編集', edit_admin_user_path(user), class: %i[btn btn-success]
   td
-    = link_to '削除', admin_user_path(user), method: :delete, class: %i[btn btn-danger]
+    = link_to '削除', admin_user_path(user), method: :delete, class: %i[btn btn-danger], data: { confirm: t('defaults.message.delete_confirm') }

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -9,6 +9,8 @@
           .box-body
             = f.input :name
 
+            = f.input :email
+
             = f.input :image, as: :file, class: 'form-control mb-3', accept: 'image/*'
             = f.hidden_field :image_cache
             .mt-3.mb-3

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,23 @@
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1
+        | Profile#edit
+
+      .box.box-primary
+        = simple_form_for(@user, url: profile_path) do |f|
+          .box-body
+            = f.input :name
+
+            = f.input :image, as: :file, class: 'form-control mb-3', accept: 'image/*'
+            = f.hidden_field :image_cache
+            .mt-3.mb-3
+              = image_tag @user.image.url,
+                          class: 'rounded-circle',
+                          id: 'preview',
+                          size: '100x100'
+
+            = f.input :role
+
+          .box-footer
+            = f.button :submit, class: %w[btn btn-primary]

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -2,10 +2,10 @@
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1
-        | Profile#edit
+        | User#edit
 
       .box.box-primary
-        = simple_form_for(@user, url: profile_path) do |f|
+        = simple_form_for(@user, url: admin_user_path) do |f|
           .box-body
             = f.input :name
 

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -2,7 +2,7 @@
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1
-        | User#edit
+        = t('.title')
 
       .box.box-primary
         = simple_form_for(@user, url: admin_user_path) do |f|

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,13 @@
+table.table.table-striped
+  thead
+    tr
+      th[scope="col"]
+        = 'id'
+      th[scope="col"]
+        = t('activerecord.attributes.user.name')
+      th[scope="col"]
+        = t('activerecord.attributes.user.role')
+      th[scope="col"]
+        = t('activerecord.attributes.user.created_at')
+  tbody
+    = render @users

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container.mb-5.pt-2
   h1
     = t('.title')

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,13 +1,28 @@
-table.table.table-striped
-  thead
-    tr
-      th[scope="col"]
-        = 'id'
-      th[scope="col"]
-        = t('activerecord.attributes.user.name')
-      th[scope="col"]
-        = t('activerecord.attributes.user.role')
-      th[scope="col"]
-        = t('activerecord.attributes.user.created_at')
-  tbody
-    = render @users
+.container.mb-5.pt-2
+  h1
+    = t('.title')
+  .row
+    .col-md-12.mb-3
+      = search_form_for @search, url: admin_users_path do |f|
+        .row
+          .form-inline.align-items-center.mx-auto
+            .col-auto
+              = f.search_field :name_cont, class: 'form-control', placeholder: '検索ワード'
+            .col-auto
+              = f.select :role_eq, User.roles_i18n.invert.map{ |key, value| [key, User.roles[value]] }, {include_blank: t('defaults.unspecified')}, class: 'form-control'
+            .col-auto
+              = f.submit value: '検索', class: 'btn btn-primary'
+
+  table.table.table-striped
+    thead
+      tr
+        th[scope="col"]
+          = 'id'
+        th[scope="col"]
+          = t('activerecord.attributes.user.name')
+        th[scope="col"]
+          = t('activerecord.attributes.user.role')
+        th[scope="col"]
+          = t('activerecord.attributes.user.created_at')
+    tbody
+      = render @users

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -2,7 +2,7 @@
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2
       h1
-        | User#show
+        = t('.title')
       .text-right.mb-3
         = link_to '編集', edit_admin_user_path(@user), class: %i[btn btn-success]
         = link_to '削除', admin_user_path(@user), method: :delete, class: %i[btn btn-danger], data: { confirm: t('defaults.message.delete_confirm') }
@@ -15,21 +15,21 @@
               = @user.id
           tr
             th[scope="row"]
-              | 権限
+              = t('activerecord.attributes.user.role')
             td
               = @user.role
           tr
             th[scope="row"]
-              | 氏名
+              = t('activerecord.attributes.user.name')
             td
               = @user.name
           tr
             th[scope="row"]
-              | アイコン
+              = t('activerecord.attributes.user.image')
             td
               = image_tag @user.image_url, size: '200x200'
           tr
             th[scope="row"]
-              | 作成日時
+              = t('activerecord.attributes.user.created_at')
             td
               = l(@user.created_at, format: :short)

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,3 +1,5 @@
+- set_meta_tags title: t('.title')
+
 .container
   .row
     .col-md-10.offset-md-1.col-lg-8.offset-lg-2

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,35 @@
+.container
+  .row
+    .col-md-10.offset-md-1.col-lg-8.offset-lg-2
+      h1
+        | User#show
+      .text-right.mb-3
+        = link_to '編集', edit_admin_user_path(@user), class: %i[btn btn-success]
+        = link_to '削除', admin_user_path(@user), method: :delete, class: %i[btn btn-danger], data: { confirm: '削除しますか？'}
+      table.table.table-bordered.bg-white
+        tbody
+          tr
+            th[scope="row"]
+              | ID
+            td
+              = @user.id
+          tr
+            th[scope="row"]
+              | 権限
+            td
+              = @user.role
+          tr
+            th[scope="row"]
+              | 氏名
+            td
+              = @user.name
+          tr
+            th[scope="row"]
+              | アイコン
+            td
+              = image_tag @user.image_url, size: '200x200'
+          tr
+            th[scope="row"]
+              | 作成日時
+            td
+              = l(@user.created_at, format: :short)

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -5,7 +5,7 @@
         | User#show
       .text-right.mb-3
         = link_to '編集', edit_admin_user_path(@user), class: %i[btn btn-success]
-        = link_to '削除', admin_user_path(@user), method: :delete, class: %i[btn btn-danger], data: { confirm: '削除しますか？'}
+        = link_to '削除', admin_user_path(@user), method: :delete, class: %i[btn btn-danger], data: { confirm: t('defaults.message.delete_confirm') }
       table.table.table-bordered.bg-white
         tbody
           tr

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -25,6 +25,7 @@ ja:
         area: 'ジャンル'
         images: '画像'
         category_ids: 'カテゴリー'
+        created_at: '作成日時'
       comment:
         body: 'コメント'
       item:
@@ -34,6 +35,7 @@ ja:
         image: '商品画像'
         rakuten_url: '楽天URL'
         amazon_url: 'AmazonURL'
+        created_at: '作成日時'
   users:
     create:
       success: 'ユーザー登録しました'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,6 +8,7 @@ ja:
     models:
       user: 'ユーザー'
       post: '投稿'
+      item: 'アイテム'
       comment: 'コメント'
     attributes:
       user:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,7 +16,8 @@ ja:
         password_confirmation: 'パスワード確認'
         description: '自己紹介'
         image: 'プロフィール画像'
-        role: 'タイプ'
+        role: '権限'
+        created_at: '作成日時'
       post:
         body: '本文'
         area: 'ジャンル'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     message:
       require_login: 'ログインしてください'
       not_authorized: '権限がありません'
+      delete_confirm: '削除しますか？'
   activerecord:
     models:
       user: 'ユーザー'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -27,6 +27,13 @@ ja:
         category_ids: 'カテゴリー'
       comment:
         body: 'コメント'
+      item:
+        item_code: '商品コード'
+        name: '商品名'
+        price: '価格'
+        image: '商品画像'
+        rakuten_url: '楽天URL'
+        amazon_url: 'AmazonURL'
   users:
     create:
       success: 'ユーザー登録しました'

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -4,3 +4,7 @@ ja:
       area:
         around: 'デスク全体'
         focus: '特定の箇所やアイテム'
+    user:
+      role:
+        admin: '管理者'
+        general: '一般'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -65,8 +65,24 @@ ja:
   admin:
     user_sessions:
       new:
-        title: '管理者用ログイン'
+        title: 'ログイン（管理画面）'
     dashboards:
       index:
-        title: 'ダッシュボード'
+        title: 'ダッシュボード（管理画面）'
+    users:
+      index: 
+        title: 'ユーザー一覧（管理画面）'
+      show:
+        title: 'ユーザー詳細（管理画面）'
+      edit:
+        title: 'ユーザー編集（管理画面）'
+    items:
+      index:
+        title: 'アイテム一覧（管理画面）'
+      show:
+        title: 'アイテム詳細（管理画面）'
+      new:
+        title: 'アイテム登録（管理画面）'
+      edit:
+        title: 'アイテム編集（管理画面）' 
       

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,7 @@ ja:
     logout: 'ログアウト'
     post: '投稿'
     profile: 'プロフィール'
+    unspecified: '指定なし'
     message:
       created: "%{item}しました"
       not_created: "%{item}できません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     post 'login', to: 'user_sessions#create'
     delete 'logout', to: 'user_sessions#destroy'
     root 'dashboards#index'
-    resources :users, only: %i[index show edit update destroy], shallow: true 
+    resources :users, only: %i[index show edit update destroy], shallow: true
     resources :items, shallow: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,5 +33,6 @@ Rails.application.routes.draw do
     delete 'logout', to: 'user_sessions#destroy'
     root 'dashboards#index'
     resources :users, only: %i[index show edit update destroy], shallow: true 
+    resources :items, shallow: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,6 @@ Rails.application.routes.draw do
     post 'login', to: 'user_sessions#create'
     delete 'logout', to: 'user_sessions#destroy'
     root 'dashboards#index'
+    resources :users, only: %i[index show edit update destroy], shallow: true 
   end
 end

--- a/db/migrate/20210514113032_add_itemcode_to_items.rb
+++ b/db/migrate/20210514113032_add_itemcode_to_items.rb
@@ -1,0 +1,5 @@
+class AddItemcodeToItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :item_code, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,121 +10,123 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_402_125_034) do
-  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+ActiveRecord::Schema.define(version: 2021_05_14_113032) do
+
+  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
-    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
+  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['name'], name: 'index_categories_on_name', unique: true
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'item_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['item_id'], name: 'index_item_tags_on_item_id'
-    t.index ['post_id'], name: 'index_item_tags_on_post_id'
+  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_tags_on_item_id"
+    t.index ["post_id"], name: "index_item_tags_on_post_id"
   end
 
-  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name'
-    t.string 'image'
-    t.string 'price'
-    t.string 'rakuten_url'
-    t.string 'amazon_url'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.string "image"
+    t.string "price"
+    t.string "rakuten_url"
+    t.string "amazon_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "item_code", null: false
   end
 
-  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_likes_on_post_id'
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'category_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'image', null: false
-    t.string 'caption'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_post_images_on_post_id'
+  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "image", null: false
+    t.string "caption"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'area', default: 0
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "area", default: 0
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', null: false
-    t.text 'description'
-    t.string 'image'
-    t.integer 'role', default: 0, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "image"
+    t.integer "role", default: 0, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'bookmarks', 'posts'
-  add_foreign_key 'bookmarks', 'users'
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'item_tags', 'items'
-  add_foreign_key 'item_tags', 'posts'
-  add_foreign_key 'likes', 'posts'
-  add_foreign_key 'likes', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'post_images', 'posts'
-  add_foreign_key 'posts', 'users'
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "item_tags", "items"
+  add_foreign_key "item_tags", "posts"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "post_images", "posts"
+  add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,123 +10,122 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_14_113032) do
-
-  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "uid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+ActiveRecord::Schema.define(version: 20_210_514_113_032) do
+  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'uid', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
   end
 
-  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_bookmarks_on_post_id"
-    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
+    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true
+  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['name'], name: 'index_categories_on_name', unique: true
   end
 
-  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body", null: false
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body', null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_comments_on_post_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "item_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["item_id"], name: "index_item_tags_on_item_id"
-    t.index ["post_id"], name: "index_item_tags_on_post_id"
+  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'item_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['item_id'], name: 'index_item_tags_on_item_id'
+    t.index ['post_id'], name: 'index_item_tags_on_post_id'
   end
 
-  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name"
-    t.string "image"
-    t.string "price"
-    t.string "rakuten_url"
-    t.string "amazon_url"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "item_code", null: false
+  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name'
+    t.string 'image'
+    t.string 'price'
+    t.string 'rakuten_url'
+    t.string 'amazon_url'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'item_code', null: false
   end
 
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_likes_on_post_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
+  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_likes_on_post_id'
+    t.index ['user_id'], name: 'index_likes_on_user_id'
   end
 
-  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "category_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
-    t.index ["category_id"], name: "index_post_categories_on_category_id"
-    t.index ["post_id"], name: "index_post_categories_on_post_id"
+  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'category_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
+    t.index ['category_id'], name: 'index_post_categories_on_category_id'
+    t.index ['post_id'], name: 'index_post_categories_on_post_id'
   end
 
-  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "image", null: false
-    t.string "caption"
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_post_images_on_post_id"
+  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'image', null: false
+    t.string 'caption'
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_post_images_on_post_id'
   end
 
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body"
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "area", default: 0
-    t.index ["user_id"], name: "index_posts_on_user_id"
+  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'area', default: 0
+    t.index ['user_id'], name: 'index_posts_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name", null: false
-    t.text "description"
-    t.string "image"
-    t.integer "role", default: 0, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name', null: false
+    t.text 'description'
+    t.string 'image'
+    t.integer 'role', default: 0, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
 
-  add_foreign_key "bookmarks", "posts"
-  add_foreign_key "bookmarks", "users"
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
-  add_foreign_key "item_tags", "items"
-  add_foreign_key "item_tags", "posts"
-  add_foreign_key "likes", "posts"
-  add_foreign_key "likes", "users"
-  add_foreign_key "post_categories", "categories"
-  add_foreign_key "post_categories", "posts"
-  add_foreign_key "post_images", "posts"
-  add_foreign_key "posts", "users"
+  add_foreign_key 'bookmarks', 'posts'
+  add_foreign_key 'bookmarks', 'users'
+  add_foreign_key 'comments', 'posts'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'item_tags', 'items'
+  add_foreign_key 'item_tags', 'posts'
+  add_foreign_key 'likes', 'posts'
+  add_foreign_key 'likes', 'users'
+  add_foreign_key 'post_categories', 'categories'
+  add_foreign_key 'post_categories', 'posts'
+  add_foreign_key 'post_images', 'posts'
+  add_foreign_key 'posts', 'users'
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  context "全てのフィールドが有効な場合" do
+  context '全てのフィールドが有効な場合' do
     it '有効である' do
       comment = build(:comment)
       expect(comment).to be_valid
     end
   end
-  context "bodyが未入力の場合" do
+  context 'bodyが未入力の場合' do
     it '無効である' do
       comment = build(:comment, body: nil)
       expect(comment).to be_invalid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,8 +68,6 @@ RSpec.configure do |config|
 
   # RSpecテスト後に画像ファイル削除の設定
   config.after(:all) do
-    if Rails.env.test?
-      FileUtils.rm_rf(Dir["#{Rails.root}/public/uploads_#{Rails.env}/"])
-    end
+    FileUtils.rm_rf(Dir["#{Rails.root}/public/uploads_#{Rails.env}/"]) if Rails.env.test?
   end
 end

--- a/spec/support/driver_setting.rb
+++ b/spec/support/driver_setting.rb
@@ -1,10 +1,10 @@
 RSpec.configure do |config|
-	# ブラウザを非表示でテストする
-	config.before(:each, type: :system) do
-		driven_by :selenium, using: :headless_chrome
-	end
-	# ブラウザを表示してテストする
-	config.before(:each, type: :system) do
-		driven_by :selenium_chrome
-	end
+  # ブラウザを非表示でテストする
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome
+  end
+  # ブラウザを表示してテストする
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome
+  end
 end

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Bookmarks", type: :system do
+RSpec.describe 'Bookmarks', type: :system do
   before do
     driven_by(:rack_test)
   end
@@ -11,62 +11,60 @@ RSpec.describe "Bookmarks", type: :system do
   let!(:post_by_others_and_bookmarked) { create(:post) }
   let!(:bookmark) { create(:bookmark, post: post_by_others_and_bookmarked, user: user) }
 
-  describe "ブックマークのCRUD" do
-
-    describe "ブックマークボタンの表示" do
-      context "他人の投稿かつ、ブックマークしていない場合" do
-        it "ブックマークボタンが表示される" do
+  describe 'ブックマークのCRUD' do
+    describe 'ブックマークボタンの表示' do
+      context '他人の投稿かつ、ブックマークしていない場合' do
+        it 'ブックマークボタンが表示される' do
           login(user)
           visit post_path(post_by_others)
           expect(page).to have_selector("#button-bookmark-#{post_by_others.id}"), 'ブックマークボタンが表示されていません'
-          expect(page).to have_selector(".far.fa-bookmark"), 'ブックマークボタンが正しく表示されていません' 
+          expect(page).to have_selector('.far.fa-bookmark'), 'ブックマークボタンが正しく表示されていません'
         end
       end
-      context "他人の投稿かつ、ブックマークしている場合" do
-        it "ブックマークボタンが表示される" do
+      context '他人の投稿かつ、ブックマークしている場合' do
+        it 'ブックマークボタンが表示される' do
           login(user)
           visit post_path(post_by_others_and_bookmarked)
           expect(page).to have_selector("#button-bookmark-#{post_by_others_and_bookmarked.id}"), 'ブックマーク済みボタンが表示されていません'
-          expect(page).to have_selector(".fas.fa-bookmark"), 'ブックマーク済みボタンが正しく表示されていません'
+          expect(page).to have_selector('.fas.fa-bookmark'), 'ブックマーク済みボタンが正しく表示されていません'
         end
       end
-      context "自分の投稿の場合" do
-        it "ブックマークボタンが表示されない" do
+      context '自分の投稿の場合' do
+        it 'ブックマークボタンが表示されない' do
           login(user)
           visit post_path(post_by_uesr)
-          expect(page).not_to have_selector("#button-bookmark-#{post_by_uesr.id}")  
+          expect(page).not_to have_selector("#button-bookmark-#{post_by_uesr.id}")
         end
       end
     end
 
-    describe "ブックマークした投稿の一覧表示" do
+    describe 'ブックマークした投稿の一覧表示' do
       context 'ログインしていない場合' do
-        it "ログインページにリダイレクトされる" do
+        it 'ログインページにリダイレクトされる' do
           visit bookmarks_posts_path
           expect(current_path).to eq(login_path), 'ログインページにリダイレクトされていません'
         end
       end
 
-      context "ログインしてる場合" do
-        it "ブックマークした投稿が表示される" do
+      context 'ログインしてる場合' do
+        it 'ブックマークした投稿が表示される' do
           login(user)
           visit bookmarks_posts_path
           expect(page).to have_selector("#post-id-#{post_by_others_and_bookmarked.id}"), 'ブックマークした投稿が表示されていません'
           expect(page).not_to have_selector("#post-id-#{post_by_others.id}"), 'ブックマークしていない投稿が表示されています'
-        end  
+        end
       end
     end
-    
-    
-    describe "ブックマークの作成" do
-      context "ログインしていない場合" do
-        it "ログインページに遷移する" do
+
+    describe 'ブックマークの作成' do
+      context 'ログインしていない場合' do
+        it 'ログインページに遷移する' do
           visit post_path(post_by_others)
           click_on "button-bookmark-#{post_by_others.id}"
           expect(current_path).to eq(login_path), 'ログインページにリダイレクトされていません'
         end
       end
-      context "ログインしている場合" do
+      context 'ログインしている場合' do
         it 'ブックマークが作成できる' do
           login(user)
           visit post_path(post_by_others)
@@ -78,22 +76,22 @@ RSpec.describe "Bookmarks", type: :system do
       end
     end
 
-    describe "ブックマークの削除" do
-      context "ログインしていない場合" do
-        it "ログインページにリダイレクトされる" do
+    describe 'ブックマークの削除' do
+      context 'ログインしていない場合' do
+        it 'ログインページにリダイレクトされる' do
           visit post_path(post_by_others_and_bookmarked)
           click_on "button-bookmark-#{post_by_others_and_bookmarked.id}"
           expect(current_path).to eq(login_path), 'ログインページにリダイレクトされていません'
         end
       end
-      context "ログインしている場合" do
-        it "ブックマークを取り消せる" do
+      context 'ログインしている場合' do
+        it 'ブックマークを取り消せる' do
           login(user)
           visit post_path(post_by_others_and_bookmarked)
           expect(page).to have_selector('.fas.fa-bookmark'), 'ブックマーク済みボタンが表示されていません'
           click_on "button-bookmark-#{post_by_others_and_bookmarked.id}"
           expect(current_path).to eq(post_path(post_by_others_and_bookmarked.id)), '投稿詳細ページに遷移していません'
-          expect(page).to have_selector('.far.fa-bookmark'), 'ブックマークボタンに変化していません'  
+          expect(page).to have_selector('.far.fa-bookmark'), 'ブックマークボタンに変化していません'
         end
       end
     end

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Comments", type: :system do
+RSpec.describe 'Comments', type: :system do
   before do
     driven_by(:rack_test)
   end
@@ -10,26 +10,26 @@ RSpec.describe "Comments", type: :system do
   let!(:comment_by_me) { create(:comment, user: me, post: post) }
   let!(:comment_by_another) { create(:comment, post: post) }
 
-  describe "コメントのCRUD" do
+  describe 'コメントのCRUD' do
     before do
       login(me)
       visit post_path(post)
     end
 
-    describe "コメントの一覧" do
-      context "投稿詳細ページにアクセス" do
-        it "投稿に紐づくコメントが表示される" do
+    describe 'コメントの一覧' do
+      context '投稿詳細ページにアクセス' do
+        it '投稿に紐づくコメントが表示される' do
           within('#js-table-comment') do
             expect(page).to have_content(comment_by_me.body)
-            expect(page).to have_content(comment_by_another.user.name)  
+            expect(page).to have_content(comment_by_another.user.name)
           end
         end
       end
     end
-    
-    describe "コメントの作成" do
-      context "コメントを入力して作成" do
-        it "作成に成功する" do
+
+    describe 'コメントの作成' do
+      context 'コメントを入力して作成' do
+        it '作成に成功する' do
           fill_in 'コメント', with: 'test'
           click_on '投稿'
           comment = Comment.last
@@ -40,21 +40,21 @@ RSpec.describe "Comments", type: :system do
         end
       end
 
-      context "コメントを未入力で作成" do
-        it "作成に失敗する" do
+      context 'コメントを未入力で作成' do
+        it '作成に失敗する' do
           fill_in 'コメント', with: ''
           click_on '投稿'
-          expect(page).to have_content('コメントできません') 
+          expect(page).to have_content('コメントできません')
         end
       end
     end
-    
-    describe "コメントの編集" do
-      context "他人のコメントの場合" do
-        it "編集ボタンと削除ボタンが表示されない" do
+
+    describe 'コメントの編集' do
+      context '他人のコメントの場合' do
+        it '編集ボタンと削除ボタンが表示されない' do
           within("#comment-#{comment_by_another.id}") do
-            #expect(page).not_to have_selector('.js-edit-comment-button')
-            #expect(page).not_to have_selector('.js-delete-comment-button')
+            # expect(page).not_to have_selector('.js-edit-comment-button')
+            # expect(page).not_to have_selector('.js-delete-comment-button')
           end
         end
       end

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Likes", type: :system do
+RSpec.describe 'Likes', type: :system do
   let(:user) { create(:user) }
   let!(:post_by_uesr) { create(:post, user: user) }
   let!(:post_by_others) { create(:post) }
@@ -11,61 +11,60 @@ RSpec.describe "Likes", type: :system do
     driven_by(:rack_test)
   end
 
-  describe "いいねのCRUD" do
-
-    describe "いいねボタンの表示" do
-      context "他人の投稿かつ、いいねしていない場合" do
-        it "いいねボタンが表示される" do
+  describe 'いいねのCRUD' do
+    describe 'いいねボタンの表示' do
+      context '他人の投稿かつ、いいねしていない場合' do
+        it 'いいねボタンが表示される' do
           login(user)
           visit post_path(post_by_others)
           expect(page).to have_selector("#button-like-#{post_by_others.id}"), 'いいねボタンが表示されていません'
-          expect(page).to have_selector(".far.fa-heart"), 'いいねボタンが正しく表示されていません' 
+          expect(page).to have_selector('.far.fa-heart'), 'いいねボタンが正しく表示されていません'
         end
       end
-      context "他人の投稿かつ、いいねしている場合" do
-        it "いいねボタンが表示される" do
+      context '他人の投稿かつ、いいねしている場合' do
+        it 'いいねボタンが表示される' do
           login(user)
           visit post_path(post_by_others_and_liked)
           expect(page).to have_selector("#button-like-#{post_by_others_and_liked.id}"), 'いいね済みボタンが表示されていません'
-          expect(page).to have_selector(".fas.fa-heart"), 'いいね済みボタンが正しく表示されていません'
+          expect(page).to have_selector('.fas.fa-heart'), 'いいね済みボタンが正しく表示されていません'
         end
       end
-      context "自分の投稿の場合" do
-        it "いいねボタンが表示されない" do
+      context '自分の投稿の場合' do
+        it 'いいねボタンが表示されない' do
           login(user)
           visit post_path(post_by_uesr)
-          expect(page).not_to have_selector("#button-like-#{post_by_uesr.id}")  
+          expect(page).not_to have_selector("#button-like-#{post_by_uesr.id}")
         end
       end
     end
 
-    describe "ブックマークした投稿の一覧表示" do
+    describe 'ブックマークした投稿の一覧表示' do
       context 'ログインしていない場合' do
-        it "ログインページにリダイレクトされる" do
+        it 'ログインページにリダイレクトされる' do
           visit likes_posts_path
           expect(current_path).to eq(login_path), 'ログインページにリダイレクトされていません'
         end
       end
 
-      context "ログインしてる場合" do
-        it "ブックマークした投稿が表示される" do
+      context 'ログインしてる場合' do
+        it 'ブックマークした投稿が表示される' do
           login(user)
           visit likes_posts_path
           expect(page).to have_selector("#post-id-#{post_by_others_and_liked.id}"), 'いいねした投稿が表示されていません'
           expect(page).not_to have_selector("#post-id-#{post_by_others.id}"), 'いいねしていない投稿が表示されています'
-        end  
+        end
       end
     end
-    
-    describe "いいねの作成" do
-      context "ログインしていない場合" do
-        it "ログインページに遷移する" do
+
+    describe 'いいねの作成' do
+      context 'ログインしていない場合' do
+        it 'ログインページに遷移する' do
           visit post_path(post_by_others)
           click_on "button-like-#{post_by_others.id}"
           expect(current_path).to eq(login_path), 'ログインページにリダイレクトされていません'
         end
       end
-      context "ログインしている場合" do
+      context 'ログインしている場合' do
         it 'いいねが作成できる' do
           login(user)
           visit post_path(post_by_others)
@@ -77,22 +76,22 @@ RSpec.describe "Likes", type: :system do
       end
     end
 
-    describe "いいねの削除" do
-      context "ログインしていない場合" do
-        it "ログインページにリダイレクトされる" do
+    describe 'いいねの削除' do
+      context 'ログインしていない場合' do
+        it 'ログインページにリダイレクトされる' do
           visit post_path(post_by_others_and_liked)
           click_on "button-like-#{post_by_others_and_liked.id}"
           expect(current_path).to eq(login_path), 'ログインページにリダイレクトされていません'
         end
       end
-      context "ログインしている場合" do
-        it "いいねを取り消せる" do
+      context 'ログインしている場合' do
+        it 'いいねを取り消せる' do
           login(user)
           visit post_path(post_by_others_and_liked)
           expect(page).to have_selector('.fas.fa-heart'), 'いいね済みボタンが表示されていません'
           click_on "button-like-#{post_by_others_and_liked.id}"
           expect(current_path).to eq(post_path(post_by_others_and_liked.id)), '投稿詳細ページに遷移していません'
-          expect(page).to have_selector('.far.fa-heart'), 'いいねボタンに変化していません'  
+          expect(page).to have_selector('.far.fa-heart'), 'いいねボタンに変化していません'
         end
       end
     end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -93,40 +93,38 @@ RSpec.describe 'Posts', type: :system do
       end
     end
 
-    describe "投稿の詳細" do
-      it "投稿の詳細が表示される" do
+    describe '投稿の詳細' do
+      it '投稿の詳細が表示される' do
         visit posts_path
         within "#post-id-#{post.id}" do
           click_on 'post-img'
         end
-        expect(current_path).to eq(post_path(post)), '詳細ページに遷移していません'  
+        expect(current_path).to eq(post_path(post)), '詳細ページに遷移していません'
         expect(page).to have_content(post.user.name), 'ユーザーの名前が表示されていません'
         expect(page).to have_content(post.body), '投稿内容が表示されていません'
       end
     end
-    
-    describe "投稿の編集" do
+
+    describe '投稿の編集' do
       let(:post_by_user) { create(:post, user: user) }
       let(:post_by_others) { create(:post) }
 
-      context "他人の投稿の場合" do
-        it "編集・削除ボタンが表示されない" do
+      context '他人の投稿の場合' do
+        it '編集・削除ボタンが表示されない' do
           login(user)
           visit post_path(post_by_others)
           expect(page).not_to have_selector("#button-edit-#{post_by_others.id}")
-          expect(page).not_to have_selector("#button-delete-#{post_by_others.id}")  
+          expect(page).not_to have_selector("#button-delete-#{post_by_others.id}")
         end
       end
-      context "自分の投稿の場合" do
-        it "編集・削除ボタンが表示される" do
+      context '自分の投稿の場合' do
+        it '編集・削除ボタンが表示される' do
           login(user)
           visit post_path(post_by_user)
           expect(page).to have_selector("#button-edit-#{post_by_user.id}")
-          expect(page).to have_selector("#button-delete-#{post_by_user.id}")  
+          expect(page).to have_selector("#button-delete-#{post_by_user.id}")
         end
       end
-      
     end
-    
   end
 end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'UserSessions', type: :system do
   before do
     driven_by(:rack_test)
   end
-  
+
   let(:user) { create(:user) }
 
   describe 'ログイン前' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe 'Users', type: :system do
   before do
     driven_by(:rack_test)
   end
-  
+
   let(:user) { create(:user) }
   let(:user_others) { create(:user) }
   let!(:post) { create(:post, user: user) }
-  let!(:post_by_others) { create(:post, user: user_others)}
+  let!(:post_by_others) { create(:post, user: user_others) }
 
   describe 'ログイン前' do
     describe 'ユーザー新規登録' do
@@ -52,26 +52,25 @@ RSpec.describe 'Users', type: :system do
     end
   end
 
-  describe "ログイン後" do
-
+  describe 'ログイン後' do
     before do
       login(user)
     end
 
-    describe "マイページの表示" do
-      context "自分のマイページを表示" do
-        it "正しく表示される" do
+    describe 'マイページの表示' do
+      context '自分のマイページを表示' do
+        it '正しく表示される' do
           visit user_path(user)
           expect(page).to have_selector("#user-id-#{user.id}"), 'ユーザー情報が表示されていません'
           expect(page).not_to have_selector("#user-id-#{user_others.id}"), '別のユーザー情報が表示されています'
           expect(page).to have_selector("#post-id-#{post.id}"), 'ユーザーの投稿が表示されていません'
           expect(page).not_to have_selector("#post-id-#{post_by_others.id}"), '他人の投稿が表示されています'
           expect(page).to have_selector("#user-link-id-#{user.id}"), 'いいねやブックマークページへのリンクが表示されていません'
-          expect(page).not_to have_selector("user-link-id-#{user_others.id}"), '他人のいいねやブックマークページへのリンクが表示されています'   
+          expect(page).not_to have_selector("user-link-id-#{user_others.id}"), '他人のいいねやブックマークページへのリンクが表示されています'
         end
       end
-      context "他人のマイページを表示" do
-        it "正しく表示される" do
+      context '他人のマイページを表示' do
+        it '正しく表示される' do
           visit user_path(user_others)
           expect(page).not_to have_selector("#user-id-#{user.id}"), '自分のユーザー情報が表示されています'
           expect(page).to have_selector("#user-id-#{user_others.id}"), 'ユーザー情報が表示されていません'
@@ -81,9 +80,9 @@ RSpec.describe 'Users', type: :system do
       end
     end
 
-    describe "プロフィールの編集" do
-      context "フォームの入力値が正常" do
-        it "更新に成功する" do
+    describe 'プロフィールの編集' do
+      context 'フォームの入力値が正常' do
+        it '更新に成功する' do
           visit edit_profile_path(user)
           fill_in 'ユーザーネーム', with: 'username'
           fill_in '自己紹介', with: 'description_test'
@@ -91,11 +90,11 @@ RSpec.describe 'Users', type: :system do
           click_on '更新する'
           expect(current_path).to eq(edit_profile_path(user)), 'ページが正しく遷移していません'
           expect(page).to have_content('プロフィールを更新しました'), 'サクセスメッセージが表示されていません'
-          expect(page).to have_selector("img[src$='20210227_005224.jpg']"), '登録した画像が表示されていません' 
+          expect(page).to have_selector("img[src$='20210227_005224.jpg']"), '登録した画像が表示されていません'
         end
       end
-      context "ユーザーネームが未入力" do
-        it "更新に失敗する" do
+      context 'ユーザーネームが未入力' do
+        it '更新に失敗する' do
           visit edit_profile_path(user)
           fill_in 'ユーザーネーム', with: ''
           click_on '更新する'


### PR DESCRIPTION
## 概要

管理画面でユーザーとアイテムのCRUD機能
#24 Closed

## 確認方法

1. 管理画面にアクセス
2. サイドメニューから「ユーザー一覧」または「アイテム一覧」を選択
3. ユーザーに関しては「編集」「削除」、アイテムに関しては「作成」「編集」「削除」ができるか 

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした

## コメント

投稿に関してのCRUDは緊急性がないため現時点では未実装