### PR TITLE
Add: フォーム入力時の個別エラーメッセージの実装とデザイン適用に伴うテストの修正

### DIFF
--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -12,9 +12,9 @@ class PostsForm
   attribute :user_id, :integer
   attribute :items
 
-  validates :images, presence: true
-  validates :category_ids, presence: true
+  validates :images, presence: true, presence: { message: :invalid_images }
   validates :area, presence: true
+  validates :category_ids, presence: true, presence: { message: :invalid_category }
 
   validate :image_content_type
   validate :image_size

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,12 +12,12 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
 
+  validates :name, presence: true, length: { maximum: 20 }
+  validates :email, uniqueness: true, presence: true
   validates :password, length: { in: 8..30 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
-  validates :email, uniqueness: true, presence: true
-  validates :name, presence: true, length: { in: 1..20 }
   validates :description, length: { maximum: 200 }
 
   enum role: { general: 0, admin: 1 }

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,4 +1,4 @@
-article.media
+article.media id="comment-#{comment.id}"
   figure.media-left
     p.image.is-48x48
       = image_tag comment.user.image_url(:thumb), class: 'is-rounded'
@@ -17,5 +17,6 @@ article.media
   .media-right
     - if current_user&.own?(comment)
       = link_to comment_path(comment), method: :delete,
-                                        data: { confirm: t('defaults.message.delete_confirm') } do
+                                       class: 'edit-comment-button',
+                                       data: { confirm: t('defaults.message.delete_confirm') } do
         button.delete

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,4 +1,5 @@
 = form_with model: @form, local: true do |f|
+  = render 'shared/error_messages', object: f.object
   .field.is-horizontal
     .field-label.is-normal
       = f.label :images, 'デスク写真', class: 'label'

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -35,7 +35,7 @@ main
                   .tile.is-child.is-hidden-mobile
                     p.title.has-text-weight-bold.is-5
                       = t('activerecord.models.comment')
-                    #comments
+                    #desktop_comments
                       = render @comments
                       - if logged_in?
                         .media
@@ -93,7 +93,7 @@ main
               .tile.is-child
                 p.title.has-text-weight-bold.is-5
                   = t('activerecord.models.comment')
-                #comments
+                #mobile_comments
                   = render @comments
                   - if logged_in?
                     article.media

--- a/app/views/profiles/_form.html.slim
+++ b/app/views/profiles/_form.html.slim
@@ -1,4 +1,5 @@
 = form_with model: @user, url: profile_path, local: true do |f|
+  = render 'shared/error_messages', object: f.object
   .field
     label.label
       = f.label :name

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,0 +1,4 @@
+- if object.errors.any?
+  .notification.is-danger.is-light
+    - object.errors.full_messages.each do |msg|
+      li = msg

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,16 +1,17 @@
 = simple_form_for @user do |f|
+  = render 'shared/error_messages', object: f.object
   .field
     .control
-      = f.input :name, label_html: { class: 'label' }, input_html: { class: 'input' }
+      = f.input :name, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
   .field
     .control
-      = f.input :email, label_html: { class: 'label' }, input_html: { class: 'input' }
+      = f.input :email, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
   .field
     .control
-      = f.input :password, label_html: { class: 'label' }, input_html: { class: 'input' }
+      = f.input :password, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
   .field
     .control
-      = f.input :password_confirmation, label_html: { class: 'label' }, input_html: { class: 'input' }
+      = f.input :password_confirmation, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
   .field
     .control
       = f.button :submit, class: %w[has-text-weight-bold button is-success is-fullwidth]

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -62,7 +62,7 @@ SimpleForm.setup do |config|
     # If you want to display the full error message for the attribute, you can
     # use the component :full_error, like:
     #
-    b.use :full_error, wrap_with: { tag: :span, class: :error }
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
   end
 
   # The default wrapper to be used by the FormBuilder.
@@ -75,7 +75,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :nested
 
   # Default class for buttons
-  config.button_class = 'btn'
+  config.button_class = 'button'
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -53,3 +53,17 @@ ja:
         fail: 'ログインに失敗しました'
       destroy:
         success: 'ログアウトしました'
+
+  activemodel:
+    errors:
+      models:
+        posts_form:
+          attributes:
+            images:
+              invalid_images: 'をアップロードしてください'
+            category_ids:
+              invalid_category: 'を一つ以上選択してください'
+    attributes:
+      posts_form:
+        images: 'デスク写真'
+        category_ids: 'カテゴリー'

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Comments', type: :system do
     describe 'コメントの一覧' do
       context '投稿詳細ページにアクセス' do
         it '投稿に紐づくコメントが表示される' do
-          within('#comments') do
+          within('#desktop_comments') do
             expect(page).to have_content(comment_by_me.body)
             expect(page).to have_content(comment_by_another.user.name)
           end
@@ -30,10 +30,10 @@ RSpec.describe 'Comments', type: :system do
     describe 'コメントの作成' do
       context 'コメントを入力して作成' do
         it '作成に成功する' do
-          fill_in 'コメント', with: 'test'
-          click_on '投稿'
-          comment = Comment.last
-          within('#comments') do
+          within('#desktop_comments') do
+            fill_in 'コメント', with: 'test'
+            click_on '投稿'
+            comment = Comment.last
             expect(page).to have_content(comment.user.name)
             expect(page).to have_content(comment.body)
           end
@@ -42,8 +42,10 @@ RSpec.describe 'Comments', type: :system do
 
       context 'コメントを未入力で作成' do
         it '作成に失敗する' do
-          fill_in 'コメント', with: ''
-          click_on '投稿'
+          within('#desktop_comments') do
+            fill_in 'コメント', with: ''
+            click_on '投稿'
+          end
           expect(page).to have_content('コメントできません')
         end
       end
@@ -52,9 +54,11 @@ RSpec.describe 'Comments', type: :system do
     describe 'コメントの編集' do
       context '他人のコメントの場合' do
         it '編集ボタンと削除ボタンが表示されない' do
-          within("#comment-#{comment_by_another.id}") do
-            # expect(page).not_to have_selector('.js-edit-comment-button')
-            # expect(page).not_to have_selector('.js-delete-comment-button')
+          within('#desktop_comments') do
+            within("#comment-#{comment_by_another.id}") do
+              # expect(page).not_to have_selector('.edit-comment-button')
+              expect(page).not_to have_selector('.delete-comment-button')
+            end
           end
         end
       end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Posts', type: :system do
           expect(current_path).to eq(posts_path)
           expect(page).to have_content('投稿しました')
           within('#new_arrival') do
-            expect(page).to have_content(user.name)
+            expect(page).to have_selector("img[src$='20210227_005224.jpg']")
           end
         end
         it '投稿の作成に失敗する' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'Posts', type: :system do
         it '投稿の作成に失敗する' do
           click_button '投稿する'
           expect(page).to have_content('投稿できません')
-          expect(page).to have_content('カテゴリーを入力してください')
-          expect(page).to have_content('画像を入力してください')
+          expect(page).to have_content('カテゴリーを一つ以上選択してください')
+          expect(page).to have_content('デスク写真をアップロードしてください')
         end
       end
     end


### PR DESCRIPTION
## 概要

- デザイン適用に伴うテストの修正
- フォーム入力時に個別のエラーメッセージを表示

Closed #58 #59 


## 影響範囲

- フォーム画面各種（ユーザー登録 / 新規投稿）

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした
- [ ] specテストをパスした

## コメント

- フォームのラベルに全てclassを付与しているが、一括で付与する方法がありそう