### PR TITLE
Add: アイテムの登録、投稿に紐付け

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -11,10 +11,10 @@ class Api::V1::ItemsController < ApplicationController
   # end
 
   def search
-    # contents = render_to_string(partial: 'item_list', locals: {items: search_by_rakuten(params[:keyword])})
-    contents = search_by_rakuten(params[:keyword])
+    @items = search_by_rakuten(params[:keyword])
     # contentsをjsonに返す
-    render json: { contents: contents }
+    # contents = render_to_string(partial: 'item_list', locals: {items: search_by_rakuten(params[:keyword])})
+    # render json: { contents: contents }
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,7 +18,6 @@ class PostsController < ApplicationController
 
   def create
     @form = PostsForm.new(post_params)
-
     if @form.save
       redirect_to posts_path, success: t('defaults.message.created', item: Post.model_name.human)
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -67,7 +67,12 @@ class PostsController < ApplicationController
       { images: [] },
       :image_cache,
       { category_ids: [] },
-      { items: [] }
+      { items1: [] },
+      { items2: [] },
+      { items3: [] },
+      { items4: [] },
+      { items5: [] }
+      #{ items: [:item_code, :name, :image, :price, :rakuten_url, :amazon_url] }
     ).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -72,7 +72,7 @@ class PostsController < ApplicationController
       { items3: [] },
       { items4: [] },
       { items5: [] }
-      #{ items: [:item_code, :name, :image, :price, :rakuten_url, :amazon_url] }
+      # { items: [:item_code, :name, :image, :price, :rakuten_url, :amazon_url] }
     ).merge(user_id: current_user.id)
   end
 end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -88,7 +88,7 @@ class PostsForm
   end
 
   def items_params
-    items = (items1 + items2 + items3).delete("")
+    items = (items1 + items2 + items3 + items4 + items5).delete("")
     return nil if items.empty?
   end
 

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -41,6 +41,15 @@ class PostsForm
       category_ids.each do |category_id|
         post.post_categories.create!(category_id: category_id)
       end
+
+      hash_items.each do |item|
+        
+        binding.pry
+        
+        # new_item = Item.new(item)
+        # new_item.save! unless Item.exists?(item_code: item.item_code)
+        # post.item_tags.create!(item_id: new_item.id)
+      end
     end
 
     true
@@ -94,5 +103,20 @@ class PostsForm
     images&.each do |image|
       errors.add(:images, 'は5MB以下のファイルまでアップロードできます') if image.size > 5.megabytes
     end
+  end
+
+  def hash_items
+    items&.each do |result|
+      item = {
+        item_code: result['item_code'],
+        name: result['name'],
+        price: result['price'],
+        image: result['image'],
+        rakuten_url: result['rakuten_url'],
+        amazon_url: result['amazon_url']
+      }
+      items << item
+    end
+    items
   end
 end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -14,6 +14,8 @@ class PostsForm
   attribute :items1
   attribute :items2
   attribute :items3
+  attribute :items4
+  attribute :items5
 
   validates :images, presence: true, presence: { message: :invalid_images }
   validates :area, presence: true
@@ -45,6 +47,7 @@ class PostsForm
         post.post_categories.create!(category_id: category_id)
       end
 
+      
       items_params&.each do |item|
         h_item = eval(item) #セキュリティホール的に非推奨らしい
         new_item = Item.new(h_item)
@@ -88,8 +91,12 @@ class PostsForm
   end
 
   def items_params
-    items = (items1 + items2 + items3 + items4 + items5).delete("")
-    return nil if items.empty?
+    items = (items1 + items2 + items3 + items4 + items5).reject(&:empty?)
+    if items.empty?
+      return nil
+    else
+      items
+    end
   end
 
   def default_attributes

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -47,16 +47,15 @@ class PostsForm
         post.post_categories.create!(category_id: category_id)
       end
 
-      
       items_params&.each do |item|
-        h_item = eval(item) #セキュリティホール的に非推奨らしい
+        h_item = eval(item) # セキュリティホール的に非推奨らしい
         new_item = Item.new(h_item)
-        unless Item.exists?(item_code: h_item[:item_code])
-          new_item.save!
-          post.item_tags.create!(item_id: new_item.id)
-        else
+        if Item.exists?(item_code: h_item[:item_code])
           exist_item = Item.find_by(item_code: h_item[:item_code])
           post.item_tags.create!(item_id: exist_item.id)
+        else
+          new_item.save!
+          post.item_tags.create!(item_id: new_item.id)
         end
       end
     end
@@ -93,7 +92,7 @@ class PostsForm
   def items_params
     items = (items1 + items2 + items3 + items4 + items5).reject(&:empty?)
     if items.empty?
-      return nil
+      nil
     else
       items
     end

--- a/app/javascript/packs/bulma.js
+++ b/app/javascript/packs/bulma.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 
   // Check for click events on the navbar burger icon
-  $(".navbar-burger").click(function() {
+  $(document).on('click', '.navbar-burger', function() {
 
       // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
       $(".navbar-burger").toggleClass("is-active");

--- a/app/javascript/packs/item_search.js
+++ b/app/javascript/packs/item_search.js
@@ -1,4 +1,8 @@
+const { Collapse } = require("bootstrap");
+
 $(function() {
+
+  // モーダルの表示・非表示
   $(document).on('click', '#item-search-show', function() {
     $(".modal").toggleClass("is-active");
   });
@@ -7,36 +11,37 @@ $(function() {
     $(".modal").removeClass("is-active");
   });
 
+  // 商品検索
   $(document).on('click', '#js-search-button', function(e) {
     e.preventDefault();
     var keyword = $('#js-search-keyword').val();
     $.ajax({
       url: '/search',
       type: "GET",
-      dataType: "json",
       async: true,
       data: { keyword: keyword },　//検索パラメーターの指定(:keyword)
     }).done(function (data) {
-      // var items = data.contents
-      // $("#item_list").html('');
-      // $.each(items, function(index, val) {
-      //   $("#item_list").append(`<div class="search-item item">` + `<img src=` + `"${val.image}" width="150" height="150">` + `<p></p>` + val.name + `<p></p>` + `¥` + val.price + `</div>`);
-      // });
-      // $("#item_list").css("display", "");
-      // $("#item_list").html(data.contents); //render json:{contents: contents}の内容表示
+      $("#item_list").css("display", "");
     });
     $('#js-search-keyword').val('');
   });
 
-  // $(this).on('click', '.item', function() {
-  //   var item = $(this)
-  //   $('#item_list').hide();
-  //   $('#item-search-box').hide();
-  //   $('#item_detail').append(item);
-  // });
+  // アイテムの選択、キャンセル
+  $(document).on('click', '.item', function() {
+    const item = $('.item-data', this).data();
+    $("#item_list").hide();
+    $("#item_detail").append(`商品名　${item.name}` + `<span class="item-data" data-amazon_url="${item.amazon_url}" data-image="${item.image}" data-item_code="${item.item_code}" data-name="${item.name}" data-price="${item.price}" data-rakuten_url="${item.rakuten_url}"></span>` + `<div class="button is-success item-select">このアイテムを選択</div>` + `<div class="button back-to-page">検索結果に戻る</div>`);
+    $(item).remove();
+  });
 
-  // $(document).on('click', '.item-search-modal-wrapper', function() {
-  //   $('#item-search-modal').fadeOut('fast');
-  // });
+  $(document).on('click', '.item-select', function() {
+    $(".modal").removeClass("is-active");
+    $("#item_list").empty();
+    $("#item_detail").empty();
+  });
 
+  $(document).on('click', '.back-to-page', function () {
+    $("#item_list").show();
+    $("#item_detail").html('');
+  });
 });

--- a/app/javascript/packs/item_search.js
+++ b/app/javascript/packs/item_search.js
@@ -1,7 +1,10 @@
 $(function() {
   $(document).on('click', '#item-search-show', function() {
-    $('#item-search-modal').show();
-    $('.modal').show();
+    $(".modal").toggleClass("is-active");
+  });
+
+  $(document).on('click', ('.delete, .modal-background'), function() {
+    $(".modal").removeClass("is-active");
   });
 
   $(document).on('click', '#js-search-button', function(e) {
@@ -14,28 +17,23 @@ $(function() {
       async: true,
       data: { keyword: keyword },　//検索パラメーターの指定(:keyword)
     }).done(function (data) {
-      var items = data.contents
-      $("#item_list").html('');
-      $.each(items, function(index, val) {
-        $("#item_list").append(`<div class="search-item item">` + `<img src=` + `"${val.image}" width="150" height="150">` + `<p></p>` + val.name + `<p></p>` + `¥` + val.price + `</div>`);
-      });
-      //$("#item_list").css("display", "");
-      //$("#item_list").html(data.contents); //render json:{contents: contents}の内容表示
+      // var items = data.contents
+      // $("#item_list").html('');
+      // $.each(items, function(index, val) {
+      //   $("#item_list").append(`<div class="search-item item">` + `<img src=` + `"${val.image}" width="150" height="150">` + `<p></p>` + val.name + `<p></p>` + `¥` + val.price + `</div>`);
+      // });
+      // $("#item_list").css("display", "");
+      // $("#item_list").html(data.contents); //render json:{contents: contents}の内容表示
     });
     $('#js-search-keyword').val('');
   });
 
-  $(this).on('click', '.item', function() {
-    var item = $(this)
-    $('#item_list').hide();
-    $('#item-search-box').hide();
-    $('#item_detail').append(item);
-  });
-
-  $(document).on('click', '#close-modal', function() {
-    $('#item-search-modal').hide();
-    $('#item_list').empty();
-  });
+  // $(this).on('click', '.item', function() {
+  //   var item = $(this)
+  //   $('#item_list').hide();
+  //   $('#item-search-box').hide();
+  //   $('#item_detail').append(item);
+  // });
 
   // $(document).on('click', '.item-search-modal-wrapper', function() {
   //   $('#item-search-modal').fadeOut('fast');

--- a/app/javascript/packs/item_search.js
+++ b/app/javascript/packs/item_search.js
@@ -30,22 +30,40 @@ $(function() {
   $(document).on('click', '.item', function() {
     const item = $('.item-data', this).data();
     $("#item_list").hide();
-    // $("#item_detail").append(`商品名　${item.name}` + `<span class="detail-item-data" data-amazon_url="${item.amazon_url}" data-image="${item.image}" data-item_code="${item.item_code}" data-name="${item.name}" data-price="${item.price}" data-rakuten_url="${item.rakuten_url}"></span>` + `<div class="button is-success item-select">このアイテムを選択</div>` + `<div class="button back-to-page">検索結果に戻る</div>`);
     $("#item_detail").append(`商品名　${item.name}` + `<span class="detail-item-data" data-detail-item='{ "amazon_url":"${item.amazon_url}", "image":"${item.image}", "item_code":"${item.item_code}", "name":"${item.name}", "price":"${item.price}", "rakuten_url":"${item.rakuten_url}" }'></span>` + `<div class="button is-success item-select">このアイテムを選択</div>` + `<div class="button back-to-page">検索結果に戻る</div>`);
-    // $(".item-select").val({ item_code: item.item_code,
-    //                         name: item.name, 
-    //                         price: item.price,
-    //                         image: item.price,
-    //                         rakuten_url: item.rakuten_url,
-    //                         amazon_url: item.amazon_url
-    //                      });
     $(item).remove();
   });
 
   $(document).on('click', '.item-select', function() {
-    const select_item = $('.detail-item-data').data('detailItem');
-    $("#post_items").val(`{ "item_code":"${select_item.item_code}", "name":"${select_item.name}", "price":"${select_item.price}", "image":"${select_item.image}", "rakuten_url":"${select_item.rakuten_url}", "amazon_url":"${select_item.amazon_url}" }`);
-    $("#item-results").text(select_item.name);
+    // アイテムデータの変数を定義
+    var select_item = $('.detail-item-data').data('detailItem');
+    var item1 = $("#post_items1").val();
+    var item2 = $("#post_items2").val();
+    var item3 = $("#post_items3").val();
+    var item4 = $("#post_items4").val();
+    // アイテム表示用のHTML変数
+    var column = '<div class="column is-half-mobile is-one-third-desktop">'
+    var item_image = '<div class="item-image"> <figure class="image is-5by4">'
+    var item_name = '<div class="item-name">'
+    var item_price = '<div class="item-price">'
+    // アイテムを5つまでフィールドに登録、表示
+    if (item1 == "") {
+      $("#post_items1").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`);
+    } else if (item1 != "" && item2 == "") {
+      $("#post_items2").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+    } else if (item1 != "" && item2 == "" && item3 == "") {
+      $("#post_items3").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+    } else if (item1 != "" && item2 == "" && item3 == "" && item4 == "") {
+      $("#post_items4").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+    } else {
+      $("#post_items5").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+    };
+    // モーダル表示の切り替え
     $(".modal").removeClass("is-active");
     $("#item_list").empty();
     $("#item_detail").empty();

--- a/app/javascript/packs/item_search.js
+++ b/app/javascript/packs/item_search.js
@@ -30,14 +30,26 @@ $(function() {
   $(document).on('click', '.item', function() {
     const item = $('.item-data', this).data();
     $("#item_list").hide();
-    $("#item_detail").append(`商品名　${item.name}` + `<span class="item-data" data-amazon_url="${item.amazon_url}" data-image="${item.image}" data-item_code="${item.item_code}" data-name="${item.name}" data-price="${item.price}" data-rakuten_url="${item.rakuten_url}"></span>` + `<div class="button is-success item-select">このアイテムを選択</div>` + `<div class="button back-to-page">検索結果に戻る</div>`);
+    // $("#item_detail").append(`商品名　${item.name}` + `<span class="detail-item-data" data-amazon_url="${item.amazon_url}" data-image="${item.image}" data-item_code="${item.item_code}" data-name="${item.name}" data-price="${item.price}" data-rakuten_url="${item.rakuten_url}"></span>` + `<div class="button is-success item-select">このアイテムを選択</div>` + `<div class="button back-to-page">検索結果に戻る</div>`);
+    $("#item_detail").append(`商品名　${item.name}` + `<span class="detail-item-data" data-detail-item='{ "amazon_url":"${item.amazon_url}", "image":"${item.image}", "item_code":"${item.item_code}", "name":"${item.name}", "price":"${item.price}", "rakuten_url":"${item.rakuten_url}" }'></span>` + `<div class="button is-success item-select">このアイテムを選択</div>` + `<div class="button back-to-page">検索結果に戻る</div>`);
+    // $(".item-select").val({ item_code: item.item_code,
+    //                         name: item.name, 
+    //                         price: item.price,
+    //                         image: item.price,
+    //                         rakuten_url: item.rakuten_url,
+    //                         amazon_url: item.amazon_url
+    //                      });
     $(item).remove();
   });
 
   $(document).on('click', '.item-select', function() {
+    const select_item = $('.detail-item-data').data('detailItem');
+    $("#post_items").val(`{ "item_code":"${select_item.item_code}", "name":"${select_item.name}", "price":"${select_item.price}", "image":"${select_item.image}", "rakuten_url":"${select_item.rakuten_url}", "amazon_url":"${select_item.amazon_url}" }`);
+    $("#item-results").text(select_item.name);
     $(".modal").removeClass("is-active");
     $("#item_list").empty();
     $("#item_detail").empty();
+    $(select_item).remove();
   });
 
   $(document).on('click', '.back-to-page', function () {

--- a/app/javascript/packs/item_search.js
+++ b/app/javascript/packs/item_search.js
@@ -49,19 +49,19 @@ $(function() {
     // アイテムを5つまでフィールドに登録、表示
     if (item1 == "") {
       $("#post_items1").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
-      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`);
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>${select_item.name.substr(0, 40)}...</p></div>` + item_price + `<p>¥${select_item.price}</p></div></div>`);
     } else if (item1 != "" && item2 == "") {
       $("#post_items2").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
-      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>${select_item.name.substr(0, 40)}...</p></div>` + item_price + `<p>¥${select_item.price}</p></div></div>`)
     } else if (item1 != "" && item2 == "" && item3 == "") {
       $("#post_items3").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
-      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>${select_item.name.substr(0, 40)}...</p></div>` + item_price + `<p>¥${select_item.price}</p></div></div>`)
     } else if (item1 != "" && item2 == "" && item3 == "" && item4 == "") {
       $("#post_items4").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
-      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>${select_item.name.substr(0, 40)}...</p></div>` + item_price + `<p>¥${select_item.price}</p></div></div>`)
     } else {
       $("#post_items5").val(`{ item_code: "${select_item.item_code}", name: "${select_item.name}", price: "${select_item.price}", image: "${select_item.image}", rakuten_url: "${select_item.rakuten_url}", amazon_url: "${select_item.amazon_url}" }`);
-      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>"${select_item.name.substr(1, 40)}..."</p></div>` + item_price + `<p>¥"${select_item.price}"</p></div></div>`)
+      $("#item-results").append(column + item_image + `<img src="${select_item.image}"></figure></div>` + item_name + `<p>${select_item.name.substr(0, 40)}...</p></div>` + item_price + `<p>¥${select_item.price}</p></div></div>`)
     };
     // モーダル表示の切り替え
     $(".modal").removeClass("is-active");

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -10,7 +10,7 @@ $(function() {
       reader.readAsDataURL(input.files[0]);
     }
   }
-  $("#post_images").change(function(){
+  $(document).on('change', '#post_images', function(){
       readURL(this);
   });
 

--- a/app/javascript/packs/user_edit.js
+++ b/app/javascript/packs/user_edit.js
@@ -8,7 +8,7 @@ $(function() {
       reader.readAsDataURL(input.files[0]);
     }
   }
-  $("#user_image").change(function(){
+  $(document).on('change', '#user_image', function(){
     readURL(this);
   });
 });

--- a/app/javascript/stylesheets/item_search_modal.scss
+++ b/app/javascript/stylesheets/item_search_modal.scss
@@ -1,28 +1,28 @@
-//モーダル表示
-.item-search-modal-wrapper {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  z-index: 100;
-  display: none; //通常時は非表示
-}
+// //モーダル表示
+// .item-search-modal-wrapper {
+//   position: fixed;
+//   top: 0;
+//   right: 0;
+//   bottom: 0;
+//   left: 0;
+//   background-color: rgba(0, 0, 0, 0.6);
+//   z-index: 100;
+//   display: none; //通常時は非表示
+// }
 
-.modal {
-  position: absolute;
-  top: 10%;
-  left: 10%;
-  background-color: #e6ecf0;
-  padding: 20px 0 40px;
-  border-radius: 10px;
-  width: 80%;
-  height: auto;
-  max-height: 80%; //スクロール時に必要
-  text-align: center;
-  overflow: auto; //スクロール時に必要
-}
+// .modal {
+//   position: absolute;
+//   top: 10%;
+//   left: 10%;
+//   background-color: #e6ecf0;
+//   padding: 20px 0 40px;
+//   border-radius: 10px;
+//   width: 80%;
+//   height: auto;
+//   max-height: 80%; //スクロール時に必要
+//   text-align: center;
+//   overflow: auto; //スクロール時に必要
+// }
 
 .fa-times {
   position: absolute;

--- a/app/views/api/v1/items/_item_detail.html.slim
+++ b/app/views/api/v1/items/_item_detail.html.slim
@@ -1,6 +1,25 @@
-= image_tag(item[:image], size:'300x300')
-= item[:name]
-= "¥#{item[:price]}"
+.tile.is-ancestor
+  .tile
+    figure.image.is-4by3
+      = image_tag @item.image
 
-#item-select.btn.btn-primary
-  <i class="fas fa-tags"></i> このアイテムを選択する
+  .tile
+    .card
+      header.card-header
+        p.card-header-title.is-size-5
+          | アイテムデータ
+      .card-content
+        .content
+          p.has-text-weight-bold.is-size-5
+            = @item.name
+          p.is-size-5
+            = "￥#{number_to_currency(@item.price)}"
+          = link_to @item.rakuten_url, class: 'button is-link is-fullwidth', target: '_blank'
+            span.icon-text
+              span
+                | 販売サイト
+              span.icon
+                i.fas.fa-external-link-alt
+
+    / #item-select.btn.btn-primary
+    /   <i class="fas fa-tags"></i> このアイテムを選択する

--- a/app/views/api/v1/items/_item_list.html.slim
+++ b/app/views/api/v1/items/_item_list.html.slim
@@ -10,4 +10,4 @@
       .item-price
         p
           = "¥#{item[:price]}"
-      span.item-data[data-item_code="#{item[:item_code]}" data-name="#{item[:name]}" data-price="#{item[:price]}" data-image="#{item[:image]}" data-rakuten_url="#{item[:rakuten_url]}" data-amazon_url="#{item[:amazon_url]}"]item_
+      span.item-data[data-item_code="#{item[:item_code]}" data-name="#{item[:name]}" data-price="#{item[:price]}" data-image="#{item[:image]}" data-rakuten_url="#{item[:rakuten_url]}" data-amazon_url="#{item[:amazon_url]}"]

--- a/app/views/api/v1/items/_item_list.html.slim
+++ b/app/views/api/v1/items/_item_list.html.slim
@@ -1,8 +1,13 @@
-- items.first(10).each do |item|
-  .search-item
-    .item
-      = image_tag(item[:image], size:'150x150')
-      p
-      = item[:name]
-      p
-      = "¥#{item[:price]}"
+- items.first(10).each_with_index do |item, index|
+  .column.is-half-mobile.is-one-third-desktop.item
+    div id="search-id-#{index}"
+      .item-image
+        figure.image.is-5by4
+          = image_tag(item[:image])
+      .item-name
+        p
+          = truncate(item[:name], length: 30)
+      .item-price
+        p
+          = "¥#{item[:price]}"
+      span.item-data[data-item_code="#{item[:item_code]}" data-name="#{item[:name]}" data-price="#{item[:price]}" data-image="#{item[:image]}" data-rakuten_url="#{item[:rakuten_url]}" data-amazon_url="#{item[:amazon_url]}"]item_

--- a/app/views/api/v1/items/search.js.erb
+++ b/app/views/api/v1/items/search.js.erb
@@ -1,6 +1,6 @@
-//$('#item_list').empty(); //既に表示されている商品を削除
+$('#item_list').empty(); //既に表示されている商品を削除
 
-//<% if items.present? %>
-//  $('#item_list').html("<%= j render 'item_list', items: items %>");　//jを用いてエスケープ処理を行っている
-//  $('#js-search-keyword').val(''); //検索ワードを削除
-//<% end %>
+<% if @items.present? %>
+  $('#item_list').html("<%= j render 'item_list', items: @items %>");　//jを用いてエスケープ処理を行っている
+  $('#js-search-keyword').val(''); //検索ワードを削除
+<% end %>

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,7 +1,8 @@
 article.media id="comment-#{comment.id}"
   figure.media-left
     p.image.is-48x48
-      = image_tag comment.user.image_url(:thumb), class: 'is-rounded'
+      = link_to user_path(comment.user), class: 'has-text-white' do
+        = image_tag comment.user.image_url(:thumb), class: 'is-rounded'
   .media-content
     .content
       p

--- a/app/views/items/_item_image.html.slim
+++ b/app/views/items/_item_image.html.slim
@@ -7,4 +7,4 @@
             = image_tag item.image, alt: 'item-img'
         .card-content
           .content
-            = truncate(item.name, length: 12)
+            = truncate(item.name, length: 30)

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -62,7 +62,10 @@
           span.icon-text
             i.fas.fa-tags
             |  アイテムを選択する
+
+        = f.hidden_field :items, multiple: true
         #item-results
+          
 
   .field.is-horizontal
     .field-label

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -62,6 +62,7 @@
           span.icon-text
             i.fas.fa-tags
             |  アイテムを選択する
+        #item-results
 
   .field.is-horizontal
     .field-label
@@ -70,19 +71,24 @@
         .control
           = f.submit '投稿する', class: %w[button is-light has-text-weight-semibold is-rounded]
 
-/ モーダル部分
-#item-search-modal.item-search-modal-wrapper
-  .modal
-    #close-modal
-      i.fa.fa-2x.fa-times
-    #item-search-box.item-search-box
+#item-search-modal.modal
+  .modal-background
+  .modal-card
+    header.modal-card-head
+      .modal-card-title.has-text-weight-bold
+        = 'アイテムを検索'
+      button.delete[aria-label="close"]
+    section.modal-card-body.item-search-box
+      / 検索結果
+      #item_list.columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
+      / 選択商品詳細
+      #item_detail
+    footer.modal-card-foot
       = form_with(url: search_path, method: :get, id: 'item_search') do |f|
-        .item-search-body
-          = f.text_field :keyword, id: 'js-search-keyword', placeholder: 'キーワードを入力'
-
-        .item-search-footer
-          = f.submit '検索', id: 'js-search-button', class: %w[btn btn-primary]
-  / 検索結果
-  #item_list
-  / 選択商品詳細
-  #item_detail
+        .field.has-addons.has-addons-centered
+          .control
+            = f.text_field :keyword, id: 'js-search-keyword', placeholder: 'キーワードを入力', class: 'input'
+          .control
+            = f.submit '検索', id: 'js-search-button', class: %w[button is-primary]
+          
+      

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -57,15 +57,27 @@
     .field-label.is-normal
       = f.label :items, class: 'label'
     .field-body
-      .control
-        #item-search-show.button
-          span.icon-text
-            i.fas.fa-tags
-            |  アイテムを選択する
+      .field
+        .control
+          #item-search-show.button
+            span.icon-text
+              i.fas.fa-tags
+              |  アイテムを選択する
 
-        = f.hidden_field :items, multiple: true
-        #item-results
-          
+          = f.hidden_field 'items1', multiple: true
+          = f.hidden_field 'items2', multiple: true
+          = f.hidden_field 'items3', multiple: true
+          = f.hidden_field 'items4', multiple: true
+          = f.hidden_field 'items5', multiple: true
+          / .tile.is-ancestor
+          /   .tile.is-parent.is-vertical
+          /     .tile.is-child
+  .field.is-horizontal
+    .field-label
+    .field-body
+      .field
+        .control
+          #item-results.columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
 
   .field.is-horizontal
     .field-label

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -16,7 +16,7 @@ main.columns.is-centered
                     p.title.is-3.has-text-weight-bold
                       = @user.name
                     p.subtitle.is-6
-                      = link_to 'プロフィールを編集', edit_profile_path, data: { turbolinks: false }
+                      = link_to 'プロフィールを編集', edit_profile_path, data: { turbolinks: false } if current_user == @user
                     p
                       = @user.description if @user.description.present?
               footer.card-footer id="user-link-id-#{@user.id}"


### PR DESCRIPTION
## 概要

- 投稿フォームからアイテムの登録
- 投稿に紐づくアイテムタグの登録

Closed #11
Closed #16 

## 確認方法

1. 投稿フォームからアイテムを検索、選択して投稿
2. 投稿詳細画面に選択したアイテムが紐づいている

## 影響範囲

- 投稿フォーム

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした
- [ ] specテストをパスした

## コメント

- アイテム登録のテストが未記入
- アイテム登録処理のロジックで非推奨メソッドを利用している（＊変更必須）
- アイテム登録処理のロジックでハッシュを利用しているので、ベストプラクティスではないと思う
- アイテム登録の上限が5つまでになっているので、後々変更