### PR TITLE
Add: カテゴリー別ページのレイアウトを整形

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,7 +3,7 @@ class CategoriesController < ApplicationController
 
   def show
     @category = Category.find_by(name: params[:name])
-    @posts = @category.post_categories.includes(post: :user).order(created_at: :desc)
+    @posts = @category.posts.includes(:user, :post_images, :categories).order(created_at: :desc)
   end
 
   private

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,12 +1,12 @@
-= content_for :title, t('.title')
-.container
-  h1
-    | Categories#show
-  p
-  h2 
-    = t("category.#{@category.name}")+'のデスク'
-  p
-  #new_arrival
-    .row.row-cols-1.row-cols-sm-2.row-cols-md-3.g-3
-      - if @posts.present?
-        = render @posts
+- set_meta_tags title: t('.title'), og: { og_title: t('.og_title')}
+
+main.columns.is-centered.is-marginless
+  .column.is-three-quarters
+    section#new_arrival
+      .container
+        br
+        p.title.has-text-weight-bold
+          = t("category.#{@category.name}")+'のデスク'
+        .columns.is-multiline.is-variable.is-3-desktop.is-1-mobile
+          - if @posts.present?
+            = render partial: 'posts/post_3col', collection: @posts

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -1,0 +1,21 @@
+.column.is-one-third-desktop
+  .card
+    div id="post-id-#{post_3col.id}"
+      = link_to post_path(post_3col)
+        .card-image
+          figure.image
+            = image_tag post_3col.post_images.first.image_url(:thumb), alt: 'post-img'
+        .card-content
+          .media
+            .media-left
+              figure.image.is-32x32
+                = image_tag post_3col.user.image_url(:thumb), class: 'is-rounded'
+            .media-content
+              p.title.is-6.has-text-weight-semibold
+                = post_3col.user.name
+              p.subtitle.is-6
+                = l post_3col.created_at, format: :short
+            .media-right
+              span.tag.is-light.is-rounded
+                .is-6
+                  = post_3col.categories[0].name

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -18,7 +18,15 @@ section.hero.is-small
                 = t('activerecord.attributes.post.category_ids')
                 = '：'
                 = link_to category_path(@post.categories[0].name) do
-                  = @post.categories[0].name 
+                  = @post.categories[0].name
+                - if @post.categories[1].present?
+                  = ' / '
+                  = link_to category_path(@post.categories[1].name) do
+                    = @post.categories[1].name
+                - if @post.categories[2].present?
+                  = ' / '
+                  = link_to category_path(@post.categories[2].name) do
+                    = @post.categories[2].name
 
 main
   section.columns.is-centered.is-marginless


### PR DESCRIPTION
## 概要

- カテゴリー別ページのレイアウトを整形
- デスクトップでは3カラム、モバイルでは1カラムで表示するためのパーシャルファイルを追加

Closed #64 

## 確認方法

## 影響範囲

- カテゴリー別ページ

## チェックリスト

- [ ] Lint のチェックをパスした

## コメント
